### PR TITLE
feat: support context cancellation under auto pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ with non-blocking commands and thus will not cause the pipeline to be blocked:
 * migrate
 * wait
 
+## Context Deadline
+
+`Client.Do()` and `Client.DoCache()` can return early if the deadline of context is reached.
+
+```golang
+ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+defer cancel()
+c.Do(ctx, c.B().Set().Key("key").Value("val").Nx().Build()).Error() == context.DeadlineExceeded
+```
+
+Please note that though operations can return early, the command is likely sent already.
+
 ## Pub/Sub
 
 To receive messages from channels, the message handler should be registered when creating the redis connection:

--- a/client.go
+++ b/client.go
@@ -54,13 +54,13 @@ func (c *singleClient) B() *cmds.Builder {
 }
 
 func (c *singleClient) Do(ctx context.Context, cmd cmds.Completed) (resp RedisResult) {
-	resp = c.conn.Do(cmd)
+	resp = c.conn.Do(ctx, cmd)
 	c.cmd.Put(cmd.CommandSlice())
 	return resp
 }
 
 func (c *singleClient) DoCache(ctx context.Context, cmd cmds.Cacheable, ttl time.Duration) (resp RedisResult) {
-	resp = c.conn.DoCache(cmd, ttl)
+	resp = c.conn.DoCache(ctx, cmd, ttl)
 	c.cmd.Put(cmd.CommandSlice())
 	return resp
 }
@@ -86,7 +86,7 @@ func (c *dedicatedSingleClient) B() *cmds.Builder {
 }
 
 func (c *dedicatedSingleClient) Do(ctx context.Context, cmd cmds.Completed) (resp RedisResult) {
-	resp = c.wire.Do(cmd)
+	resp = c.wire.Do(ctx, cmd)
 	c.cmd.Put(cmd.CommandSlice())
 	return resp
 }
@@ -95,7 +95,7 @@ func (c *dedicatedSingleClient) DoMulti(ctx context.Context, multi ...cmds.Compl
 	if len(multi) == 0 {
 		return nil
 	}
-	resp = c.wire.DoMulti(multi...)
+	resp = c.wire.DoMulti(ctx, multi...)
 	for _, cmd := range multi {
 		c.cmd.Put(cmd.CommandSlice())
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -51,21 +51,21 @@ func (m *mockConn) Store(w wire) {
 	}
 }
 
-func (m *mockConn) Do(cmd cmds.Completed) RedisResult {
+func (m *mockConn) Do(ctx context.Context, cmd cmds.Completed) RedisResult {
 	if m.DoFn != nil {
 		return m.DoFn(cmd)
 	}
 	return RedisResult{}
 }
 
-func (m *mockConn) DoCache(cmd cmds.Cacheable, ttl time.Duration) RedisResult {
+func (m *mockConn) DoCache(ctx context.Context, cmd cmds.Cacheable, ttl time.Duration) RedisResult {
 	if m.DoCacheFn != nil {
 		return m.DoCacheFn(cmd, ttl)
 	}
 	return RedisResult{}
 }
 
-func (m *mockConn) DoMulti(multi ...cmds.Completed) []RedisResult {
+func (m *mockConn) DoMulti(ctx context.Context, multi ...cmds.Completed) []RedisResult {
 	if m.DoMultiFn != nil {
 		return m.DoMultiFn(multi...)
 	}

--- a/mux.go
+++ b/mux.go
@@ -2,9 +2,7 @@ package rueidis
 
 import (
 	"context"
-	"errors"
 	"net"
-	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -246,6 +244,5 @@ func isNetworkErr(err error) bool {
 	return err != nil &&
 		err != ErrClosing &&
 		err != context.Canceled &&
-		err != context.DeadlineExceeded &&
-		!errors.Is(err, os.ErrDeadlineExceeded)
+		err != context.DeadlineExceeded
 }

--- a/mux.go
+++ b/mux.go
@@ -1,6 +1,7 @@
 package rueidis
 
 import (
+	"context"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -144,12 +145,12 @@ func (m *mux) Error() error {
 	return m.pipe().Error()
 }
 
-func (m *mux) Do(cmd cmds.Completed) (resp RedisResult) {
+func (m *mux) Do(ctx context.Context, cmd cmds.Completed) (resp RedisResult) {
 retry:
 	if cmd.IsBlock() {
-		resp = m.blocking(cmd)
+		resp = m.blocking(ctx, cmd)
 	} else {
-		resp = m.pipeline(cmd)
+		resp = m.pipeline(ctx, cmd)
 	}
 	if cmd.IsReadOnly() && isNetworkErr(resp.NonRedisError()) {
 		goto retry
@@ -157,7 +158,7 @@ retry:
 	return resp
 }
 
-func (m *mux) DoMulti(multi ...cmds.Completed) (resp []RedisResult) {
+func (m *mux) DoMulti(ctx context.Context, multi ...cmds.Completed) (resp []RedisResult) {
 	var block, write bool
 	for _, cmd := range multi {
 		block = block || cmd.IsBlock()
@@ -165,9 +166,9 @@ func (m *mux) DoMulti(multi ...cmds.Completed) (resp []RedisResult) {
 	}
 retry:
 	if block {
-		resp = m.blockingMulti(multi)
+		resp = m.blockingMulti(ctx, multi)
 	} else {
-		resp = m.pipelineMulti(multi)
+		resp = m.pipelineMulti(ctx, multi)
 	}
 	if !write {
 		for _, r := range resp {
@@ -179,31 +180,31 @@ retry:
 	return resp
 }
 
-func (m *mux) blocking(cmd cmds.Completed) (resp RedisResult) {
+func (m *mux) blocking(ctx context.Context, cmd cmds.Completed) (resp RedisResult) {
 	wire := m.pool.Acquire()
-	resp = wire.Do(cmd)
+	resp = wire.Do(ctx, cmd)
 	m.pool.Store(wire)
 	return resp
 }
 
-func (m *mux) blockingMulti(cmd []cmds.Completed) (resp []RedisResult) {
+func (m *mux) blockingMulti(ctx context.Context, cmd []cmds.Completed) (resp []RedisResult) {
 	wire := m.pool.Acquire()
-	resp = wire.DoMulti(cmd...)
+	resp = wire.DoMulti(ctx, cmd...)
 	m.pool.Store(wire)
 	return resp
 }
 
-func (m *mux) pipeline(cmd cmds.Completed) (resp RedisResult) {
+func (m *mux) pipeline(ctx context.Context, cmd cmds.Completed) (resp RedisResult) {
 	wire := m.pipe()
-	if resp = wire.Do(cmd); isNetworkErr(resp.NonRedisError()) {
+	if resp = wire.Do(ctx, cmd); isNetworkErr(resp.NonRedisError()) {
 		m.wire.CompareAndSwap(wire, m.init)
 	}
 	return resp
 }
 
-func (m *mux) pipelineMulti(cmd []cmds.Completed) (resp []RedisResult) {
+func (m *mux) pipelineMulti(ctx context.Context, cmd []cmds.Completed) (resp []RedisResult) {
 	wire := m.pipe()
-	resp = wire.DoMulti(cmd...)
+	resp = wire.DoMulti(ctx, cmd...)
 	for _, r := range resp {
 		if isNetworkErr(r.NonRedisError()) {
 			m.wire.CompareAndSwap(wire, m.init)
@@ -213,10 +214,10 @@ func (m *mux) pipelineMulti(cmd []cmds.Completed) (resp []RedisResult) {
 	return resp
 }
 
-func (m *mux) DoCache(cmd cmds.Cacheable, ttl time.Duration) RedisResult {
+func (m *mux) DoCache(ctx context.Context, cmd cmds.Cacheable, ttl time.Duration) RedisResult {
 retry:
 	wire := m.pipe()
-	resp := wire.DoCache(cmd, ttl)
+	resp := wire.DoCache(ctx, cmd, ttl)
 	if isNetworkErr(resp.NonRedisError()) {
 		m.wire.CompareAndSwap(wire, m.init)
 		goto retry
@@ -240,5 +241,5 @@ func (m *mux) Close() {
 }
 
 func isNetworkErr(err error) bool {
-	return err != nil && err != ErrClosing
+	return err != nil && err != ErrClosing && err != context.Canceled && err != context.DeadlineExceeded
 }

--- a/mux.go
+++ b/mux.go
@@ -2,7 +2,9 @@ package rueidis
 
 import (
 	"context"
+	"errors"
 	"net"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -241,5 +243,9 @@ func (m *mux) Close() {
 }
 
 func isNetworkErr(err error) bool {
-	return err != nil && err != ErrClosing && err != context.Canceled && err != context.DeadlineExceeded
+	return err != nil &&
+		err != ErrClosing &&
+		err != context.Canceled &&
+		err != context.DeadlineExceeded &&
+		!errors.Is(err, os.ErrDeadlineExceeded)
 }

--- a/mux_test.go
+++ b/mux_test.go
@@ -4,9 +4,7 @@ import (
 	"bufio"
 	"context"
 	"errors"
-	"fmt"
 	"net"
-	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -325,22 +323,6 @@ func TestMuxCMDRetry(t *testing.T) {
 
 	t.Run("not retry read with context.DeadlineExceeded", func(t *testing.T) {
 		e := context.DeadlineExceeded
-		m, checkClean := setupMux([]*mockWire{{
-			DoFn:      func(cmd cmds.Completed) RedisResult { return newErrResult(e) },
-			DoMultiFn: func(cmd ...cmds.Completed) []RedisResult { return []RedisResult{newErrResult(e)} },
-		}})
-		defer checkClean(t)
-		defer m.Close()
-		if _, err := m.Do(context.Background(), cmds.NewReadOnlyCompleted([]string{"READONLY_COMMAND"})).ToString(); err != e {
-			t.Fatalf("unexpected error %v", err)
-		}
-		if _, err := m.DoMulti(context.Background(), cmds.NewReadOnlyCompleted([]string{"READONLY_COMMAND"}))[0].ToString(); err != e {
-			t.Fatalf("unexpected error %v", err)
-		}
-	})
-
-	t.Run("not retry read with os.DeadlineExceeded", func(t *testing.T) {
-		e := fmt.Errorf("%w", os.ErrDeadlineExceeded)
 		m, checkClean := setupMux([]*mockWire{{
 			DoFn:      func(cmd cmds.Completed) RedisResult { return newErrResult(e) },
 			DoMultiFn: func(cmd ...cmds.Completed) []RedisResult { return []RedisResult{newErrResult(e)} },

--- a/pipe.go
+++ b/pipe.go
@@ -500,7 +500,14 @@ func (p *pipe) DoCache(ctx context.Context, cmd cmds.Cacheable, ttl time.Duratio
 	} else if entry != nil {
 		return newResult(entry.Wait(), nil)
 	}
-	exec, err := p.DoMulti(ctx, cmds.OptInCmd, cmds.MultiCmd, cmds.NewCompleted([]string{"PTTL", ck}), cmds.Completed(cmd), cmds.ExecCmd)[4].ToArray()
+	exec, err := p.DoMulti(
+		ctx,
+		cmds.OptInCmd,
+		cmds.MultiCmd,
+		cmds.NewCompleted([]string{"PTTL", ck}),
+		cmds.Completed(cmd),
+		cmds.ExecCmd,
+	)[4].ToArray()
 	if err != nil {
 		return newErrResult(err)
 	}

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -3,10 +3,8 @@ package rueidis
 import (
 	"bufio"
 	"context"
-	"errors"
 	"io"
 	"net"
-	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -785,7 +783,7 @@ func TestOngoingDeadlineContextInSyncMode_Do(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*time.Second/2))
 	defer cancel()
 
-	if err := p.Do(ctx, cmds.NewCompleted([]string{"GET", "a"})).NonRedisError(); !errors.Is(err, os.ErrDeadlineExceeded) {
+	if err := p.Do(ctx, cmds.NewCompleted([]string{"GET", "a"})).NonRedisError(); err != context.DeadlineExceeded {
 		t.Fatalf("unexpected err %v", err)
 	}
 	p.Close()
@@ -798,7 +796,7 @@ func TestOngoingDeadlineContextInSyncMode_DoMulti(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*time.Second/2))
 	defer cancel()
 
-	if err := p.DoMulti(ctx, cmds.NewCompleted([]string{"GET", "a"}))[0].NonRedisError(); !errors.Is(err, os.ErrDeadlineExceeded) {
+	if err := p.DoMulti(ctx, cmds.NewCompleted([]string{"GET", "a"}))[0].NonRedisError(); err != context.DeadlineExceeded {
 		t.Fatalf("unexpected err %v", err)
 	}
 	p.Close()

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -2,6 +2,7 @@ package rueidis
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net"
 	"runtime"
@@ -208,7 +209,7 @@ func TestOnDisconnectedHook(t *testing.T) {
 		close(done)
 	})
 	closeConn()
-	if err := p.Do(cmds.NewCompleted([]string{"PING"})).Error(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
+	if err := p.Do(context.Background(), cmds.NewCompleted([]string{"PING"})).Error(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
 		t.Errorf("unexpected err %v", err)
 	}
 	<-done
@@ -218,7 +219,7 @@ func TestWriteSingleFlush(t *testing.T) {
 	p, mock, cancel, _ := setup(t, ClientOption{})
 	defer cancel()
 	go func() { mock.Expect("PING").ReplyString("OK") }()
-	ExpectOK(t, p.Do(cmds.NewCompleted([]string{"PING"})))
+	ExpectOK(t, p.Do(context.Background(), cmds.NewCompleted([]string{"PING"})))
 }
 
 func TestIgnoreOutOfBandDataDuringSyncMode(t *testing.T) {
@@ -227,7 +228,7 @@ func TestIgnoreOutOfBandDataDuringSyncMode(t *testing.T) {
 	go func() {
 		mock.Expect("PING").Reply(RedisMessage{typ: '>', string: "This should be ignore"}).ReplyString("OK")
 	}()
-	ExpectOK(t, p.Do(cmds.NewCompleted([]string{"PING"})))
+	ExpectOK(t, p.Do(context.Background(), cmds.NewCompleted([]string{"PING"})))
 }
 
 func TestWriteSinglePipelineFlush(t *testing.T) {
@@ -239,7 +240,7 @@ func TestWriteSinglePipelineFlush(t *testing.T) {
 
 	for i := 0; i < times; i++ {
 		go func() {
-			ExpectOK(t, p.Do(cmds.NewCompleted([]string{"PING"})))
+			ExpectOK(t, p.Do(context.Background(), cmds.NewCompleted([]string{"PING"})))
 		}()
 	}
 	for i := 0; i < times; i++ {
@@ -253,7 +254,7 @@ func TestWriteMultiFlush(t *testing.T) {
 	go func() {
 		mock.Expect("PING").Expect("PING").ReplyString("OK").ReplyString("OK")
 	}()
-	for _, resp := range p.DoMulti(cmds.NewCompleted([]string{"PING"}), cmds.NewCompleted([]string{"PING"})) {
+	for _, resp := range p.DoMulti(context.Background(), cmds.NewCompleted([]string{"PING"}), cmds.NewCompleted([]string{"PING"})) {
 		ExpectOK(t, resp)
 	}
 }
@@ -267,7 +268,7 @@ func TestWriteMultiPipelineFlush(t *testing.T) {
 
 	for i := 0; i < times; i++ {
 		go func() {
-			for _, resp := range p.DoMulti(cmds.NewCompleted([]string{"PING"}), cmds.NewCompleted([]string{"PING"})) {
+			for _, resp := range p.DoMulti(context.Background(), cmds.NewCompleted([]string{"PING"}), cmds.NewCompleted([]string{"PING"})) {
 				ExpectOK(t, resp)
 			}
 		}()
@@ -305,7 +306,7 @@ func TestResponseSequenceWithPushMessageInjected(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			v := strconv.Itoa(i)
-			if val, _ := p.Do(cmds.NewCompleted([]string{"GET", v})).ToMessage(); val.string != v {
+			if val, _ := p.Do(context.Background(), cmds.NewCompleted([]string{"GET", v})).ToMessage(); val.string != v {
 				t.Errorf("out of order response, expected %v, got %v", v, val.string)
 			}
 		}(i)
@@ -358,7 +359,7 @@ func TestClientSideCaching(t *testing.T) {
 	for i := 0; i < 5000; i++ {
 		go func() {
 			defer wg.Done()
-			v, _ := p.DoCache(cmds.Cacheable(cmds.NewCompleted([]string{"GET", "a"})), 10*time.Second).ToMessage()
+			v, _ := p.DoCache(context.Background(), cmds.Cacheable(cmds.NewCompleted([]string{"GET", "a"})), 10*time.Second).ToMessage()
 			if v.string != "1" {
 				t.Errorf("unexpected cached result, expected %v, got %v", "1", v.string)
 			}
@@ -386,7 +387,7 @@ func TestClientSideCaching(t *testing.T) {
 	}()
 
 	for {
-		if v, _ := p.DoCache(cmds.Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string == "2" {
+		if v, _ := p.DoCache(context.Background(), cmds.Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string == "2" {
 			break
 		}
 		t.Logf("waiting for invalidating")
@@ -399,7 +400,7 @@ func TestClientSideCaching(t *testing.T) {
 	}()
 
 	for {
-		if v, _ := p.DoCache(cmds.Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string == "3" {
+		if v, _ := p.DoCache(context.Background(), cmds.Cacheable(cmds.NewCompleted([]string{"GET", "a"})), time.Second).ToMessage(); v.string == "3" {
 			break
 		}
 		t.Logf("waiting for invalidating")
@@ -423,7 +424,7 @@ func TestClientSideCachingExecAbort(t *testing.T) {
 			Reply(RedisMessage{typ: '_'})
 	}()
 
-	v, err := p.DoCache(cmds.Cacheable(cmds.NewCompleted([]string{"GET", "a"})), 10*time.Second).ToMessage()
+	v, err := p.DoCache(context.Background(), cmds.Cacheable(cmds.NewCompleted([]string{"GET", "a"})), 10*time.Second).ToMessage()
 	if !IsRedisNil(err) {
 		t.Errorf("unexpected err, got %v", err)
 	}
@@ -454,8 +455,8 @@ func TestPubSub(t *testing.T) {
 		}()
 
 		for _, c := range commands {
-			p.Do(c)
-			if v, _ := p.Do(builder.Get().Key("k").Build()).ToMessage(); v.string != "v" {
+			p.Do(context.Background(), c)
+			if v, _ := p.Do(context.Background(), builder.Get().Key("k").Build()).ToMessage(); v.string != "v" {
 				t.Fatalf("no-reply commands should not affect nornal commands")
 			}
 		}
@@ -479,8 +480,8 @@ func TestPubSub(t *testing.T) {
 			mock.Expect("GET", "k").ReplyString("v")
 		}()
 
-		p.DoMulti(commands...)
-		if v, _ := p.Do(builder.Get().Key("k").Build()).ToMessage(); v.string != "v" {
+		p.DoMulti(context.Background(), commands...)
+		if v, _ := p.Do(context.Background(), builder.Get().Key("k").Build()).ToMessage(); v.string != "v" {
 			t.Fatalf("no-reply commands should not affect nornal commands")
 		}
 	})
@@ -506,7 +507,7 @@ func TestPubSub(t *testing.T) {
 						close(done)
 					}
 				}()
-				p.DoMulti(cmd, builder.Get().Key("any").Build())
+				p.DoMulti(context.Background(), cmd, builder.Get().Key("any").Build())
 			}()
 			<-done
 		}
@@ -543,7 +544,7 @@ func TestPubSub(t *testing.T) {
 			},
 		})
 		activate := builder.Subscribe().Channel("a").Build()
-		go p.Do(activate)
+		go p.Do(context.Background(), activate)
 		mock.Expect(activate.Commands()...).Reply(
 			RedisMessage{typ: '>', values: []RedisMessage{
 				{typ: '+', string: "message"},
@@ -599,7 +600,7 @@ func TestExitOnWriteError(t *testing.T) {
 	closeConn()
 
 	for i := 0; i < 2; i++ {
-		if err := p.Do(cmds.NewCompleted([]string{"GET", "a"})).NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
+		if err := p.Do(context.Background(), cmds.NewCompleted([]string{"GET", "a"})).NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
 			t.Errorf("unexpected cached result, expected io err, got %v", err)
 		}
 	}
@@ -617,7 +618,7 @@ func TestExitOnPubSubSubscribeWriteError(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			atomic.AddInt64(&count, 1)
-			if err := p.Do(activate).NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
+			if err := p.Do(context.Background(), activate).NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
 				t.Errorf("unexpected result, expected io err, got %v", err)
 			}
 		}()
@@ -635,7 +636,7 @@ func TestExitOnWriteMultiError(t *testing.T) {
 	closeConn()
 
 	for i := 0; i < 2; i++ {
-		if err := p.DoMulti(cmds.NewCompleted([]string{"GET", "a"}))[0].NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
+		if err := p.DoMulti(context.Background(), cmds.NewCompleted([]string{"GET", "a"}))[0].NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
 			t.Errorf("unexpected result, expected io err, got %v", err)
 		}
 	}
@@ -646,7 +647,7 @@ func TestExitAllGoroutineOnWriteError(t *testing.T) {
 
 	// start the background worker
 	activate := cmds.NewBuilder(cmds.NoSlot).Subscribe().Channel("a").Build()
-	go conn.Do(activate)
+	go conn.Do(context.Background(), activate)
 	mock.Expect(activate.Commands()...)
 
 	closeConn()
@@ -655,10 +656,10 @@ func TestExitAllGoroutineOnWriteError(t *testing.T) {
 	for i := 0; i < 5000; i++ {
 		go func() {
 			defer wg.Done()
-			if err := conn.Do(cmds.NewCompleted([]string{"GET", "a"})).NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
+			if err := conn.Do(context.Background(), cmds.NewCompleted([]string{"GET", "a"})).NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
 				t.Errorf("unexpected result, expected io err, got %v", err)
 			}
-			if err := conn.DoMulti(cmds.NewCompleted([]string{"GET", "a"}))[0].NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
+			if err := conn.DoMulti(context.Background(), cmds.NewCompleted([]string{"GET", "a"}))[0].NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
 				t.Errorf("unexpected result, expected io err, got %v", err)
 			}
 		}()
@@ -675,7 +676,7 @@ func TestExitOnReadError(t *testing.T) {
 	}()
 
 	for i := 0; i < 2; i++ {
-		if err := p.Do(cmds.NewCompleted([]string{"GET", "a"})).NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
+		if err := p.Do(context.Background(), cmds.NewCompleted([]string{"GET", "a"})).NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
 			t.Errorf("unexpected result, expected io err, got %v", err)
 		}
 	}
@@ -690,7 +691,7 @@ func TestExitOnReadMultiError(t *testing.T) {
 	}()
 
 	for i := 0; i < 2; i++ {
-		if err := p.DoMulti(cmds.NewCompleted([]string{"GET", "a"}))[0].NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
+		if err := p.DoMulti(context.Background(), cmds.NewCompleted([]string{"GET", "a"}))[0].NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
 			t.Errorf("unexpected result, expected io err, got %v", err)
 		}
 	}
@@ -709,10 +710,10 @@ func TestExitAllGoroutineOnReadError(t *testing.T) {
 	for i := 0; i < 5000; i++ {
 		go func() {
 			defer wg.Done()
-			if err := p.Do(cmds.NewCompleted([]string{"GET", "a"})).NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
+			if err := p.Do(context.Background(), cmds.NewCompleted([]string{"GET", "a"})).NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
 				t.Errorf("unexpected result, expected io err, got %v", err)
 			}
-			if err := p.DoMulti(cmds.NewCompleted([]string{"GET", "a"}))[0].NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
+			if err := p.DoMulti(context.Background(), cmds.NewCompleted([]string{"GET", "a"}))[0].NonRedisError(); err != io.EOF && !strings.HasPrefix(err.Error(), "io:") {
 				t.Errorf("unexpected result, expected io err, got %v", err)
 			}
 		}()
@@ -733,7 +734,7 @@ func TestCloseAndWaitPendingCMDs(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			if v, _ := p.Do(cmds.NewCompleted([]string{"GET", "a"})).ToMessage(); v.string != "b" {
+			if v, _ := p.Do(context.Background(), cmds.NewCompleted([]string{"GET", "a"})).ToMessage(); v.string != "b" {
 				t.Errorf("unexpected GET result %v", v.string)
 			}
 		}()

--- a/rueidis.go
+++ b/rueidis.go
@@ -58,6 +58,10 @@ type ClientOption struct {
 	// Dialer can be used to customized how rueidis connect to a redis instance via TCP, including:
 	// - Timeout, the default is DefaultDialTimeout
 	// - KeepAlive, the default is DefaultTCPKeepAlive
+	// The Dialer.KeepAlive interval is used to detect an unresponsive tcp connection.
+	// OS takes at least (tcp_keepalive_probes+1)*Dialer.KeepAlive time to conclude a connection to be unresponsive.
+	// For example: DefaultTCPKeepAlive = 1s and the default of tcp_keepalive_probes on Linux is 9.
+	// Therefore, it takes at least 10s to kill an unresponsive tcp connection on Linux by default.
 	Dialer    net.Dialer
 	TLSConfig *tls.Config
 

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -477,13 +477,12 @@ func TestSentinelClientDelegateRetry(t *testing.T) {
 							{typ: '+', string: ""}, {typ: '+', string: "1"},
 						}}},
 					}
-				} else {
-					return []RedisResult{
-						{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
-						{val: RedisMessage{typ: '*', values: []RedisMessage{
-							{typ: '+', string: ""}, {typ: '+', string: "2"},
-						}}},
-					}
+				}
+				return []RedisResult{
+					{val: RedisMessage{typ: '*', values: []RedisMessage{}}},
+					{val: RedisMessage{typ: '*', values: []RedisMessage{
+						{typ: '+', string: ""}, {typ: '+', string: "2"},
+					}}},
 				}
 			},
 		}


### PR DESCRIPTION
Support context deadline or cancellation with minimum overhead.

1. set context deadline to tcp connection while the `pipe` is in sync mode
2. check context channel if necessary while the `pipe` is in pipeline mode
