### PR TITLE
fix: cluster failover to the same hostname and broken pipe in sync mode

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -22,6 +22,7 @@ type mockConn struct {
 	AcquireFn  func() wire
 	StoreFn    func(w wire)
 	OverrideFn func(c conn)
+	IsFn       func(addr string) bool
 }
 
 func (m *mockConn) Override(c conn) {
@@ -96,6 +97,13 @@ func (m *mockConn) Close() {
 	if m.CloseFn != nil {
 		m.CloseFn()
 	}
+}
+
+func (m *mockConn) Is(addr string) bool {
+	if m.IsFn != nil {
+		return m.IsFn(addr)
+	}
+	return false
 }
 
 func TestNewSingleClientNoNode(t *testing.T) {

--- a/internal/cmds/cmds.go
+++ b/internal/cmds/cmds.go
@@ -35,6 +35,10 @@ var (
 	QuitCmd = Completed{
 		cs: &CommandSlice{s: []string{"QUIT"}},
 	}
+	// PingCmd is predefined PING
+	PingCmd = Completed{
+		cs: &CommandSlice{s: []string{"PING"}},
+	}
 	// SlotCmd is predefined CLUSTER SLOTS
 	SlotCmd = Completed{
 		cs: &CommandSlice{s: []string{"CLUSTER", "SLOTS"}},

--- a/pipe.go
+++ b/pipe.go
@@ -33,6 +33,7 @@ type pipe struct {
 	state   int32
 	slept   int32
 	version int32
+	timeout time.Duration
 
 	once  sync.Once
 	cond  sync.Cond
@@ -68,6 +69,8 @@ func newPipe(conn net.Conn, option *ClientOption) (p *pipe, err error) {
 
 		subs:  newSubs(),
 		psubs: newSubs(),
+
+		timeout: option.ConnWriteTimeout,
 	}
 
 	helloCmd := []string{"HELLO", "3"}
@@ -137,22 +140,32 @@ func (p *pipe) background() {
 
 func (p *pipe) _background() {
 	wg := sync.WaitGroup{}
-	wg.Add(2)
 	exit := func() {
 		// stop accepting new requests
 		atomic.CompareAndSwapInt32(&p.state, 1, 2)
 		_ = p.conn.Close() // force both read & write goroutine to exit
 		wg.Done()
 	}
+	wg.Add(1)
 	go func() {
 		p._backgroundWrite()
 		exit()
 	}()
+	wg.Add(1)
 	go func() {
 		p._backgroundRead()
 		exit()
 		p._awake()
 	}()
+	if p.timeout > 0 {
+		go func() {
+			if err := p._backgroundPing(); err != ErrClosing {
+				p.error.CompareAndSwap(nil, &errs{error: err})
+				atomic.CompareAndSwapInt32(&p.state, 1, 2)
+				_ = p.conn.Close() // force both read & write goroutine to exit
+			}
+		}()
+	}
 	wg.Wait()
 
 	p.subs.Close()
@@ -314,6 +327,40 @@ func (p *pipe) _backgroundRead() {
 			}
 		}
 	}
+}
+
+func (p *pipe) _backgroundPing() error {
+	var timer *time.Timer
+	for atomic.LoadInt32(&p.state) == 1 {
+		ws := atomic.AddInt32(&p.waits, 1)
+		ch := p.queue.PutOne(cmds.PingCmd)
+		if ws == 1 {
+			p._awake()
+		}
+		if timer == nil {
+			timer = time.NewTimer(p.timeout)
+		} else {
+			timer.Reset(p.timeout)
+		}
+		select {
+		case resp := <-ch:
+			atomic.AddInt32(&p.waits, -1)
+			if !timer.Stop() {
+				<-timer.C
+			}
+			if err := resp.NonRedisError(); err != nil {
+				return err
+			}
+		case <-timer.C:
+			go func() {
+				<-ch
+				atomic.AddInt32(&p.waits, -1)
+			}()
+			return context.DeadlineExceeded
+		}
+		time.Sleep(time.Second)
+	}
+	return ErrClosing
 }
 
 func (p *pipe) handlePush(values []RedisMessage) {
@@ -534,6 +581,9 @@ func (p *pipe) syncDo(ctx context.Context, cmd cmds.Completed) (resp RedisResult
 	if dl, ok := ctx.Deadline(); ok {
 		p.conn.SetDeadline(dl)
 		defer p.conn.SetDeadline(time.Time{})
+	} else if p.timeout > 0 {
+		p.conn.SetDeadline(time.Now().Add(p.timeout))
+		defer p.conn.SetDeadline(time.Time{})
 	}
 
 	var msg RedisMessage
@@ -557,6 +607,9 @@ func (p *pipe) syncDo(ctx context.Context, cmd cmds.Completed) (resp RedisResult
 func (p *pipe) syncDoMulti(ctx context.Context, resp []RedisResult, multi []cmds.Completed) []RedisResult {
 	if dl, ok := ctx.Deadline(); ok {
 		p.conn.SetDeadline(dl)
+		defer p.conn.SetDeadline(time.Time{})
+	} else if p.timeout > 0 {
+		p.conn.SetDeadline(time.Now().Add(p.timeout))
 		defer p.conn.SetDeadline(time.Time{})
 	}
 
@@ -644,16 +697,15 @@ func (p *pipe) Error() error {
 
 func (p *pipe) Close() {
 	p.error.CompareAndSwap(nil, errClosing)
-	atomic.CompareAndSwapInt32(&p.state, 0, 2)
-	atomic.CompareAndSwapInt32(&p.state, 1, 2)
 	atomic.AddInt32(&p.waits, 1)
+	stopping1 := atomic.CompareAndSwapInt32(&p.state, 0, 2)
+	stopping2 := atomic.CompareAndSwapInt32(&p.state, 1, 2)
 	if p.queue != nil {
 		p.background()
 		p._awake()
-		for atomic.LoadInt32(&p.waits) != 1 {
-			runtime.Gosched()
+		if stopping1 || stopping2 {
+			<-p.queue.PutOne(cmds.QuitCmd)
 		}
-		<-p.queue.PutOne(cmds.QuitCmd)
 	}
 	atomic.AddInt32(&p.waits, -1)
 	atomic.CompareAndSwapInt32(&p.state, 2, 3)

--- a/redis_test.go
+++ b/redis_test.go
@@ -307,7 +307,10 @@ func run(t *testing.T, client Client, cases ...func(*testing.T, Client)) {
 }
 
 func TestSingleClientIntegration(t *testing.T) {
-	client, err := NewClient(ClientOption{InitAddress: []string{"127.0.0.1:6379"}})
+	client, err := NewClient(ClientOption{
+		InitAddress:      []string{"127.0.0.1:6379"},
+		ConnWriteTimeout: 120 * time.Second,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -319,7 +322,8 @@ func TestSingleClientIntegration(t *testing.T) {
 
 func TestSentinelClientIntegration(t *testing.T) {
 	client, err := NewClient(ClientOption{
-		InitAddress: []string{"127.0.0.1:26379"},
+		InitAddress:      []string{"127.0.0.1:26379"},
+		ConnWriteTimeout: 120 * time.Second,
 		Sentinel: SentinelOption{
 			MasterSet: "test",
 		},
@@ -335,8 +339,9 @@ func TestSentinelClientIntegration(t *testing.T) {
 
 func TestClusterClientIntegration(t *testing.T) {
 	client, err := NewClient(ClientOption{
-		InitAddress: []string{"127.0.0.1:7001", "127.0.0.1:7002", "127.0.0.1:7003"},
-		ShuffleInit: true,
+		InitAddress:      []string{"127.0.0.1:7001", "127.0.0.1:7002", "127.0.0.1:7003"},
+		ConnWriteTimeout: 120 * time.Second,
+		ShuffleInit:      true,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/rueidis.go
+++ b/rueidis.go
@@ -25,7 +25,7 @@ const (
 
 var (
 	// ErrClosing means the Client.Close had been called
-	ErrClosing = errors.New("rueidis client is closing")
+	ErrClosing = errors.New("rueidis client is closing or unable to connect redis")
 	// ErrNoAddr means the ClientOption.InitAddress is empty
 	ErrNoAddr = errors.New("no alive address in InitAddress")
 )

--- a/rueidis.go
+++ b/rueidis.go
@@ -67,9 +67,10 @@ type ClientOption struct {
 	// The default is DefaultPoolSize.
 	BlockingPoolSize int
 
-	// ConnWriteTimeout is used to apply net.Conn.SetWriteDeadline
+	// ConnWriteTimeout is applied net.Conn.SetWriteDeadline and periodic PING to redis
 	// Since the Dialer.KeepAlive will not be triggered if there is data in the outgoing buffer,
 	// ConnWriteTimeout should be set in order to detect local congestion or unresponsive redis server.
+	// This default is ClientOption.Dialer.KeepAlive * (9+1), where 9 is the default of tcp_keepalive_probes on Linux.
 	ConnWriteTimeout time.Duration
 
 	// ShuffleInit is a handy flag that shuffles the InitAddress after passing to the NewClient() if it is true
@@ -186,6 +187,9 @@ func dial(dst string, opt *ClientOption) (conn net.Conn, err error) {
 	}
 	if opt.Dialer.KeepAlive == 0 {
 		opt.Dialer.KeepAlive = DefaultTCPKeepAlive
+	}
+	if opt.ConnWriteTimeout == 0 {
+		opt.ConnWriteTimeout = opt.Dialer.KeepAlive * 10
 	}
 	if opt.TLSConfig != nil {
 		conn, err = tls.DialWithDialer(&opt.Dialer, "tcp", dst, opt.TLSConfig)

--- a/rueidis_test.go
+++ b/rueidis_test.go
@@ -47,7 +47,6 @@ func TestNewClusterClient(t *testing.T) {
 		}
 		slots, _ := slotsResp.ToMessage()
 		mock.Expect("CLUSTER", "SLOTS").Reply(slots)
-		mock.Expect("QUIT").ReplyString("OK")
 		close(done)
 	}()
 


### PR DESCRIPTION
* reconnect redis if the MOVED redirects to the same host (ex: AWS MemoryDB)
* improve cluster failover by also trying all replicas and initial nodes in the original InitAddress
* fix borken pipe handling in sync mode