### PR TITLE
Add CacheInvalidateCallback

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -121,7 +121,9 @@ func newPipe(conn net.Conn, option *ClientOption) (p *pipe, err error) {
 		}
 	}
 	p.cacheInvalidateCallback = option.CacheInvalidateCallback
-
+	if p.cacheInvalidateCallback != nil {
+		p.background()
+	}
 	return p, nil
 }
 

--- a/pipe.go
+++ b/pipe.go
@@ -54,7 +54,7 @@ type pipe struct {
 	ssubs                   *subs
 	pshks                   atomic.Value
 	error                   atomic.Value
-	cacheInvalidateCallback *CacheInvalidateCallbackFunc
+	cacheInvalidateCallback CacheInvalidateCallbackFunc
 }
 
 func newPipe(conn net.Conn, option *ClientOption) (p *pipe, err error) {
@@ -402,9 +402,9 @@ func (p *pipe) handlePush(values []RedisMessage) (reply bool) {
 		}
 		if p.cacheInvalidateCallback != nil {
 			if values[1].IsNil() {
-				(*p.cacheInvalidateCallback)(nil)
+				p.cacheInvalidateCallback(nil)
 			} else {
-				(*p.cacheInvalidateCallback)(values[1].values)
+				p.cacheInvalidateCallback(values[1].values)
 			}
 		}
 	case "message":

--- a/rueidis.go
+++ b/rueidis.go
@@ -13,6 +13,8 @@ import (
 	"github.com/rueian/rueidis/internal/cmds"
 )
 
+type CacheInvalidateCallbackFunc func([]RedisMessage)
+
 const (
 	// DefaultCacheBytes is the default value of ClientOption.CacheSizeEachConn, which is 128 MiB
 	DefaultCacheBytes = 128 * (1 << 20)
@@ -88,6 +90,8 @@ type ClientOption struct {
 	DisableRetry bool
 	// DisableCache falls back Client.DoCache/Client.DoMultiCache to Client.Do/Client.DoMulti
 	DisableCache bool
+	// CacheInvalidateCallback calls function in case of invalidation
+	CacheInvalidateCallback *CacheInvalidateCallbackFunc
 }
 
 // SentinelOption contains MasterSet,

--- a/rueidis.go
+++ b/rueidis.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rueian/rueidis/internal/cmds"
 )
 
-type CacheInvalidateCallbackFunc func([]RedisMessage)
+type OnInvalidationsFunc func([]RedisMessage)
 
 const (
 	// DefaultCacheBytes is the default value of ClientOption.CacheSizeEachConn, which is 128 MiB
@@ -90,8 +90,8 @@ type ClientOption struct {
 	DisableRetry bool
 	// DisableCache falls back Client.DoCache/Client.DoMultiCache to Client.Do/Client.DoMulti
 	DisableCache bool
-	// CacheInvalidateCallback calls function in case of invalidation
-	CacheInvalidateCallback CacheInvalidateCallbackFunc
+	// OnInvalidations calls function in case of invalidation
+	OnInvalidations OnInvalidationsFunc
 }
 
 // SentinelOption contains MasterSet,

--- a/rueidis.go
+++ b/rueidis.go
@@ -91,7 +91,7 @@ type ClientOption struct {
 	// DisableCache falls back Client.DoCache/Client.DoMultiCache to Client.Do/Client.DoMulti
 	DisableCache bool
 	// CacheInvalidateCallback calls function in case of invalidation
-	CacheInvalidateCallback *CacheInvalidateCallbackFunc
+	CacheInvalidateCallback CacheInvalidateCallbackFunc
 }
 
 // SentinelOption contains MasterSet,


### PR DESCRIPTION
We use redis client caching with BCAST so we have to implement custom mechanism.
I also added p.background() because otherwise it didn't get called.