### PR TITLE
feat: rueidishook

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,12 @@ func main() {
 }
 ```
 
+## Hooks and Other Observability Integration
+
+In addition to `rueidisotel`, `rueidishook` provides a general hook mechanism to intercept `rueidis.Client` interface.
+
+See [rueidishook](./rueidishook) for more details.
+
 ## Distributed Locks with client side caching
 
 See [rueidislock](./rueidislock) for more details.

--- a/rueidishook/README.md
+++ b/rueidishook/README.md
@@ -1,0 +1,65 @@
+# rueidishook
+
+With `rueidishook.WithHook`, users can easily intercept `rueidis.Client` by implementing custom `rueidishook.Hook` handler.
+
+This can be useful to change the behavior of `rueidis.Client` or add other integrations such as observability, APM etc.
+
+## Example
+
+```go
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/rueian/rueidis"
+	"github.com/rueian/rueidis/rueidishook"
+)
+
+type hook struct{}
+
+func (h *hook) Do(client rueidis.Client, ctx context.Context, cmd rueidishook.Completed) (resp rueidis.RedisResult) {
+	// do whatever you want before client.Do
+	resp = client.Do(ctx, cmd)
+	// do whatever you want after client.Do
+	return
+}
+
+func (h *hook) DoMulti(client rueidis.Client, ctx context.Context, multi ...rueidishook.Completed) (resps []rueidis.RedisResult) {
+	// do whatever you want before client.DoMulti
+	resps = client.DoMulti(ctx, multi...)
+	// do whatever you want after client.DoMulti
+	return
+}
+
+func (h *hook) DoCache(client rueidis.Client, ctx context.Context, cmd rueidishook.Cacheable, ttl time.Duration) (resp rueidis.RedisResult) {
+	// do whatever you want before client.DoCache
+	resp = client.DoCache(ctx, cmd, ttl)
+	// do whatever you want after client.DoCache
+	return
+}
+
+func (h *hook) DoMultiCache(client rueidis.Client, ctx context.Context, multi ...rueidis.CacheableTTL) (resps []rueidis.RedisResult) {
+	// do whatever you want before client.DoMultiCache
+	resps = client.DoMultiCache(ctx, multi...)
+	// do whatever you want after client.DoMultiCache
+	return
+}
+
+func (h *hook) Receive(client rueidis.Client, ctx context.Context, subscribe rueidishook.Completed, fn func(msg rueidis.PubSubMessage)) (err error) {
+	// do whatever you want before client.Receive
+	err = client.Receive(ctx, subscribe, fn)
+	// do whatever you want after client.Receive
+	return
+}
+
+func main() {
+	client, err := rueidis.NewClient(rueidis.ClientOption{InitAddress: []string{"127.0.0.1:6379"}})
+	if err != nil {
+		panic(err)
+	}
+	client = rueidishook.WithHook(client, &hook{})
+	defer client.Close()
+}
+```

--- a/rueidishook/hook.go
+++ b/rueidishook/hook.go
@@ -1,0 +1,137 @@
+package rueidishook
+
+import (
+	"context"
+	"time"
+
+	"github.com/rueian/rueidis"
+	"github.com/rueian/rueidis/internal/cmds"
+)
+
+type (
+	Completed = cmds.Completed
+	Cacheable = cmds.Cacheable
+)
+
+var _ rueidis.Client = (*hookclient)(nil)
+
+type Hook interface {
+	Do(client rueidis.Client, ctx context.Context, cmd Completed) (resp rueidis.RedisResult)
+	DoMulti(client rueidis.Client, ctx context.Context, multi ...Completed) (resps []rueidis.RedisResult)
+	DoCache(client rueidis.Client, ctx context.Context, cmd Cacheable, ttl time.Duration) (resp rueidis.RedisResult)
+	DoMultiCache(client rueidis.Client, ctx context.Context, multi ...rueidis.CacheableTTL) (resps []rueidis.RedisResult)
+	Receive(client rueidis.Client, ctx context.Context, subscribe Completed, fn func(msg rueidis.PubSubMessage)) (err error)
+}
+
+func WithHook(client rueidis.Client, hook Hook) rueidis.Client {
+	return &hookclient{client: client, hook: hook}
+}
+
+type hookclient struct {
+	client rueidis.Client
+	hook   Hook
+}
+
+func (c *hookclient) B() cmds.Builder {
+	return c.client.B()
+}
+
+func (c *hookclient) Do(ctx context.Context, cmd cmds.Completed) (resp rueidis.RedisResult) {
+	return c.hook.Do(c.client, ctx, cmd)
+}
+
+func (c *hookclient) DoMulti(ctx context.Context, multi ...cmds.Completed) (resp []rueidis.RedisResult) {
+	return c.hook.DoMulti(c.client, ctx, multi...)
+}
+
+func (c *hookclient) DoCache(ctx context.Context, cmd cmds.Cacheable, ttl time.Duration) (resp rueidis.RedisResult) {
+	return c.hook.DoCache(c.client, ctx, cmd, ttl)
+}
+
+func (c *hookclient) DoMultiCache(ctx context.Context, multi ...rueidis.CacheableTTL) (resps []rueidis.RedisResult) {
+	return c.hook.DoMultiCache(c.client, ctx, multi...)
+}
+
+func (c *hookclient) Dedicated(fn func(rueidis.DedicatedClient) error) (err error) {
+	return c.client.Dedicated(func(client rueidis.DedicatedClient) error {
+		return fn(&dedicated{client: &extended{client}, hook: c.hook})
+	})
+}
+
+func (c *hookclient) Dedicate() (rueidis.DedicatedClient, func()) {
+	client, cancel := c.client.Dedicate()
+	return &dedicated{client: &extended{client}, hook: c.hook}, cancel
+}
+
+func (c *hookclient) Receive(ctx context.Context, subscribe cmds.Completed, fn func(msg rueidis.PubSubMessage)) (err error) {
+	return c.hook.Receive(c.client, ctx, subscribe, fn)
+}
+
+func (c *hookclient) Nodes() map[string]rueidis.Client {
+	nodes := c.client.Nodes()
+	for addr, client := range nodes {
+		nodes[addr] = &hookclient{client: client}
+	}
+	return nodes
+}
+
+func (c *hookclient) Close() {
+	c.client.Close()
+}
+
+var _ rueidis.DedicatedClient = (*dedicated)(nil)
+
+type dedicated struct {
+	client *extended
+	hook   Hook
+}
+
+func (d *dedicated) B() cmds.Builder {
+	return d.client.B()
+}
+
+func (d *dedicated) Do(ctx context.Context, cmd cmds.Completed) (resp rueidis.RedisResult) {
+	return d.hook.Do(d.client, ctx, cmd)
+}
+
+func (d *dedicated) DoMulti(ctx context.Context, multi ...cmds.Completed) (resp []rueidis.RedisResult) {
+	return d.hook.DoMulti(d.client, ctx, multi...)
+}
+
+func (d *dedicated) Receive(ctx context.Context, subscribe cmds.Completed, fn func(msg rueidis.PubSubMessage)) (err error) {
+	return d.hook.Receive(d.client, ctx, subscribe, fn)
+}
+
+func (d *dedicated) SetPubSubHooks(hooks rueidis.PubSubHooks) <-chan error {
+	return d.client.SetPubSubHooks(hooks)
+}
+
+func (d *dedicated) Close() {
+	d.client.Close()
+}
+
+var _ rueidis.Client = (*extended)(nil)
+
+type extended struct {
+	rueidis.DedicatedClient
+}
+
+func (e *extended) DoCache(ctx context.Context, cmd cmds.Cacheable, ttl time.Duration) (resp rueidis.RedisResult) {
+	panic("DoCache() is not allowed with rueidis.DedicatedClient")
+}
+
+func (e *extended) DoMultiCache(ctx context.Context, multi ...rueidis.CacheableTTL) (resp []rueidis.RedisResult) {
+	panic("DoMultiCache() is not allowed with rueidis.DedicatedClient")
+}
+
+func (e *extended) Dedicated(fn func(rueidis.DedicatedClient) error) (err error) {
+	panic("Dedicated() is not allowed with rueidis.DedicatedClient")
+}
+
+func (e *extended) Dedicate() (client rueidis.DedicatedClient, cancel func()) {
+	panic("Dedicate() is not allowed with rueidis.DedicatedClient")
+}
+
+func (e *extended) Nodes() map[string]rueidis.Client {
+	panic("Nodes() is not allowed with rueidis.DedicatedClient")
+}

--- a/rueidishook/hook_test.go
+++ b/rueidishook/hook_test.go
@@ -1,0 +1,248 @@
+package rueidishook
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rueian/rueidis"
+	"github.com/rueian/rueidis/mock"
+)
+
+type hook struct{}
+
+func (h *hook) Do(client rueidis.Client, ctx context.Context, cmd Completed) (resp rueidis.RedisResult) {
+	return client.Do(ctx, cmd)
+}
+
+func (h *hook) DoMulti(client rueidis.Client, ctx context.Context, multi ...Completed) (resps []rueidis.RedisResult) {
+	return client.DoMulti(ctx, multi...)
+}
+
+func (h *hook) DoCache(client rueidis.Client, ctx context.Context, cmd Cacheable, ttl time.Duration) (resp rueidis.RedisResult) {
+	return client.DoCache(ctx, cmd, ttl)
+}
+
+func (h *hook) DoMultiCache(client rueidis.Client, ctx context.Context, multi ...rueidis.CacheableTTL) (resps []rueidis.RedisResult) {
+	return client.DoMultiCache(ctx, multi...)
+}
+
+func (h *hook) Receive(client rueidis.Client, ctx context.Context, subscribe Completed, fn func(msg rueidis.PubSubMessage)) (err error) {
+	return client.Receive(ctx, subscribe, fn)
+}
+
+type wronghook struct {
+	DoFn func(client rueidis.Client)
+}
+
+func (w *wronghook) Do(client rueidis.Client, ctx context.Context, cmd Completed) (resp rueidis.RedisResult) {
+	w.DoFn(client)
+	return rueidis.RedisResult{}
+}
+
+func (w *wronghook) DoMulti(client rueidis.Client, ctx context.Context, multi ...Completed) (resps []rueidis.RedisResult) {
+	panic("implement me")
+}
+
+func (w *wronghook) DoCache(client rueidis.Client, ctx context.Context, cmd Cacheable, ttl time.Duration) (resp rueidis.RedisResult) {
+	panic("implement me")
+}
+
+func (w *wronghook) DoMultiCache(client rueidis.Client, ctx context.Context, multi ...rueidis.CacheableTTL) (resps []rueidis.RedisResult) {
+	panic("implement me")
+}
+
+func (w *wronghook) Receive(client rueidis.Client, ctx context.Context, subscribe Completed, fn func(msg rueidis.PubSubMessage)) (err error) {
+	panic("implement me")
+}
+
+func testHooked(t *testing.T, hooked rueidis.Client, mocked *mock.Client) {
+	ctx := context.Background()
+	{
+		mocked.EXPECT().Do(ctx, mock.Match("GET", "a")).Return(mock.Result(mock.RedisNil()))
+		if err := hooked.Do(ctx, hooked.B().Get().Key("a").Build()).Error(); !rueidis.IsRedisNil(err) {
+			t.Fatalf("unexpected err %v", err)
+		}
+	}
+	{
+		mocked.EXPECT().DoCache(ctx, mock.Match("GET", "b"), time.Second).Return(mock.Result(mock.RedisNil()))
+		if err := hooked.DoCache(ctx, hooked.B().Get().Key("b").Cache(), time.Second).Error(); !rueidis.IsRedisNil(err) {
+			t.Fatalf("unexpected err %v", err)
+		}
+	}
+	{
+		mocked.EXPECT().DoMulti(ctx, mock.Match("GET", "c")).Return([]rueidis.RedisResult{mock.Result(mock.RedisNil())})
+		for _, resp := range hooked.DoMulti(ctx, hooked.B().Get().Key("c").Build()) {
+			if err := resp.Error(); !rueidis.IsRedisNil(err) {
+				t.Fatalf("unexpected err %v", err)
+			}
+		}
+	}
+	{
+		mocked.EXPECT().DoMultiCache(ctx, mock.Match("GET", "e")).Return([]rueidis.RedisResult{mock.Result(mock.RedisNil())})
+		for _, resp := range hooked.DoMultiCache(ctx, rueidis.CT(hooked.B().Get().Key("e").Cache(), time.Second)) {
+			if err := resp.Error(); !rueidis.IsRedisNil(err) {
+				t.Fatalf("unexpected err %v", err)
+			}
+		}
+	}
+	{
+		mocked.EXPECT().Receive(ctx, mock.Match("SUBSCRIBE", "a"), gomock.Any()).DoAndReturn(func(ctx context.Context, cmd any, fn func(msg rueidis.PubSubMessage)) error {
+			fn(rueidis.PubSubMessage{
+				Channel: "s",
+				Message: "s",
+			})
+			return errors.New("any")
+		})
+		if err := hooked.Receive(ctx, hooked.B().Subscribe().Channel("a").Build(), func(msg rueidis.PubSubMessage) {
+			if msg.Message != "s" && msg.Channel != "s" {
+				t.Fatalf("unexpected val %v", msg)
+			}
+		}); err.Error() != "any" {
+			t.Fatalf("unexpected err %v", err)
+		}
+	}
+	{
+		mocked.EXPECT().Nodes().Return(map[string]rueidis.Client{"addr": mocked})
+		if nodes := hooked.Nodes(); nodes["addr"].(*hookclient).client != mocked {
+			t.Fatalf("unexpected val %v", nodes)
+		}
+	}
+	{
+		ch := make(chan struct{})
+		mocked.EXPECT().Close().Do(func() { close(ch) })
+		hooked.Close()
+		<-ch
+	}
+}
+
+func testHookedDedicated(t *testing.T, hooked rueidis.DedicatedClient, mocked *mock.DedicatedClient) {
+	ctx := context.Background()
+	{
+		mocked.EXPECT().Do(ctx, mock.Match("GET", "a")).Return(mock.Result(mock.RedisNil()))
+		if err := hooked.Do(ctx, hooked.B().Get().Key("a").Build()).Error(); !rueidis.IsRedisNil(err) {
+			t.Fatalf("unexpected err %v", err)
+		}
+	}
+	{
+		mocked.EXPECT().DoMulti(ctx, mock.Match("GET", "c")).Return([]rueidis.RedisResult{mock.Result(mock.RedisNil())})
+		for _, resp := range hooked.DoMulti(ctx, hooked.B().Get().Key("c").Build()) {
+			if err := resp.Error(); !rueidis.IsRedisNil(err) {
+				t.Fatalf("unexpected err %v", err)
+			}
+		}
+	}
+	{
+		mocked.EXPECT().Receive(ctx, mock.Match("SUBSCRIBE", "a"), gomock.Any()).DoAndReturn(func(ctx context.Context, cmd any, fn func(msg rueidis.PubSubMessage)) error {
+			fn(rueidis.PubSubMessage{
+				Channel: "s",
+				Message: "s",
+			})
+			return errors.New("any")
+		})
+		if err := hooked.Receive(ctx, hooked.B().Subscribe().Channel("a").Build(), func(msg rueidis.PubSubMessage) {
+			if msg.Message != "s" && msg.Channel != "s" {
+				t.Fatalf("unexpected val %v", msg)
+			}
+		}); err.Error() != "any" {
+			t.Fatalf("unexpected err %v", err)
+		}
+	}
+	{
+		mocked.EXPECT().SetPubSubHooks(rueidis.PubSubHooks{})
+		hooked.SetPubSubHooks(rueidis.PubSubHooks{})
+	}
+	{
+		ch := make(chan struct{})
+		mocked.EXPECT().Close().Do(func() { close(ch) })
+		hooked.Close()
+		<-ch
+	}
+}
+
+func TestWithHook(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mocked := mock.NewClient(ctrl)
+	hooked := WithHook(mocked, &hook{})
+
+	testHooked(t, hooked, mocked)
+	{
+		dc := mock.NewDedicatedClient(ctrl)
+		mocked.EXPECT().Dedicate().Return(dc, func() {})
+		c, _ := hooked.Dedicate()
+		testHookedDedicated(t, c, dc)
+	}
+	{
+		dc := mock.NewDedicatedClient(ctrl)
+		cb := func(c rueidis.DedicatedClient) error {
+			testHookedDedicated(t, c, dc)
+			return errors.New("any")
+		}
+		mocked.EXPECT().Dedicated(gomock.Any()).DoAndReturn(func(fn func(c rueidis.DedicatedClient) error) error {
+			return fn(dc)
+		})
+		if err := hooked.Dedicated(cb); err.Error() != "any" {
+			t.Fatalf("unexpected err %v", err)
+		}
+	}
+}
+
+func TestForbiddenMethodForDedicatedClient(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mocked := mock.NewClient(ctrl)
+
+	shouldpanic := func(fn func(client rueidis.Client), msg string) {
+		defer func() {
+			if err := recover().(string); err != msg {
+				t.Fatalf("unexpected err %v", err)
+			}
+		}()
+
+		hooked := WithHook(mocked, &wronghook{DoFn: fn})
+		mocked.EXPECT().Dedicated(gomock.Any()).DoAndReturn(func(fn func(c rueidis.DedicatedClient) error) error {
+			return fn(mock.NewDedicatedClient(ctrl))
+		})
+		hooked.Dedicated(func(client rueidis.DedicatedClient) error {
+			return client.Do(context.Background(), client.B().Get().Key("").Build()).Error()
+		})
+	}
+	for _, c := range []struct {
+		fn  func(client rueidis.Client)
+		msg string
+	}{
+		{
+			fn: func(client rueidis.Client) {
+				client.DoCache(context.Background(), client.B().Get().Key("").Cache(), time.Second)
+			},
+			msg: "DoCache() is not allowed with rueidis.DedicatedClient",
+		}, {
+			fn: func(client rueidis.Client) {
+				client.DoMultiCache(context.Background())
+			},
+			msg: "DoMultiCache() is not allowed with rueidis.DedicatedClient",
+		}, {
+			fn: func(client rueidis.Client) {
+				client.Dedicated(func(client rueidis.DedicatedClient) error { return nil })
+			},
+			msg: "Dedicated() is not allowed with rueidis.DedicatedClient",
+		}, {
+			fn: func(client rueidis.Client) {
+				client.Dedicate()
+			},
+			msg: "Dedicate() is not allowed with rueidis.DedicatedClient",
+		}, {
+			fn: func(client rueidis.Client) {
+				client.Nodes()
+			},
+			msg: "Nodes() is not allowed with rueidis.DedicatedClient",
+		},
+	} {
+		shouldpanic(c.fn, c.msg)
+	}
+}


### PR DESCRIPTION
Allow users to intercept `rueidis.Client` interface by wrapping it with another `rueidishook.Hook` interface:

```go
package main

import (
	"context"
	"time"

	"github.com/rueian/rueidis"
	"github.com/rueian/rueidis/rueidishook"
)

type hook struct{}

func (h *hook) Do(client rueidis.Client, ctx context.Context, cmd rueidishook.Completed) (resp rueidis.RedisResult) {
	return client.Do(ctx, cmd)
}

func (h *hook) DoMulti(client rueidis.Client, ctx context.Context, multi ...rueidishook.Completed) (resps []rueidis.RedisResult) {
	return client.DoMulti(ctx, multi...)
}

func (h *hook) DoCache(client rueidis.Client, ctx context.Context, cmd rueidishook.Cacheable, ttl time.Duration) (resp rueidis.RedisResult) {
	return client.DoCache(ctx, cmd, ttl)
}

func (h *hook) DoMultiCache(client rueidis.Client, ctx context.Context, multi ...rueidis.CacheableTTL) (resps []rueidis.RedisResult) {
	return client.DoMultiCache(ctx, multi...)
}

func (h *hook) Receive(client rueidis.Client, ctx context.Context, subscribe rueidishook.Completed, fn func(msg rueidis.PubSubMessage)) (err error) {
	return client.Receive(ctx, subscribe, fn)
}

func main() {
	client, err := rueidis.NewClient(rueidis.ClientOption{InitAddress: []string{"127.0.0.1:6379"}})
	if err != nil {
		panic(err)
	}
	client = rueidishook.WithHook(client, &hook{})
	defer client.Close()
}

```