### PR TITLE
feat: om Repository.SaveMulti to batch saving multiple om records

### DIFF
--- a/om/hash_test.go
+++ b/om/hash_test.go
@@ -179,4 +179,42 @@ func TestNewHashRepository(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("SaveMulti", func(t *testing.T) {
+		entities := []*HashTestStruct{
+			repo.NewEntity(),
+			repo.NewEntity(),
+			repo.NewEntity(),
+		}
+
+		for _, e := range entities {
+			e.Val = []byte("any")
+		}
+
+		for i, err := range repo.SaveMulti(context.Background(), entities...) {
+			if err != nil {
+				t.Fatal(err)
+			}
+			if entities[i].Ver != 1 {
+				t.Fatalf("unexpected ver %d", entities[i].Ver)
+			}
+		}
+
+		entities[len(entities)-1].Ver = 0
+
+		for i, err := range repo.SaveMulti(context.Background(), entities...) {
+			if i == len(entities)-1 {
+				if err != ErrVersionMismatch {
+					t.Fatalf("unexpected err %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if entities[i].Ver != 2 {
+					t.Fatalf("unexpected ver %d", entities[i].Ver)
+				}
+			}
+		}
+	})
 }

--- a/om/json_test.go
+++ b/om/json_test.go
@@ -153,4 +153,42 @@ func TestNewJSONRepository(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("SaveMulti", func(t *testing.T) {
+		entities := []*JSONTestStruct{
+			repo.NewEntity(),
+			repo.NewEntity(),
+			repo.NewEntity(),
+		}
+
+		for _, e := range entities {
+			e.Val = []byte("any")
+		}
+
+		for i, err := range repo.SaveMulti(context.Background(), entities...) {
+			if err != nil {
+				t.Fatal(err)
+			}
+			if entities[i].Ver != 1 {
+				t.Fatalf("unexpected ver %d", entities[i].Ver)
+			}
+		}
+
+		entities[len(entities)-1].Ver = 0
+
+		for i, err := range repo.SaveMulti(context.Background(), entities...) {
+			if i == len(entities)-1 {
+				if err != ErrVersionMismatch {
+					t.Fatalf("unexpected err %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if entities[i].Ver != 2 {
+					t.Fatalf("unexpected ver %d", entities[i].Ver)
+				}
+			}
+		}
+	})
 }

--- a/om/repo.go
+++ b/om/repo.go
@@ -42,6 +42,7 @@ type Repository[T any] interface {
 	Search(ctx context.Context, cmdFn func(search FtSearchIndex) Completed) (int64, []*T, error)
 	Aggregate(ctx context.Context, cmdFn func(search FtAggregateIndex) Completed) (*AggregateCursor, error)
 	Save(ctx context.Context, entity *T) (err error)
+	SaveMulti(ctx context.Context, entity ...*T) (errs []error)
 	Remove(ctx context.Context, id string) error
 	CreateIndex(ctx context.Context, cmdFn func(schema FtCreateSchema) Completed) error
 	DropIndex(ctx context.Context) error


### PR DESCRIPTION
Resolves #115

Add `SaveMulti` to `om. Repository`. Usage example:
```go
package main

import (
	"context"
	"fmt"

	"github.com/rueian/rueidis"
	"github.com/rueian/rueidis/om"
)

type obj struct {
	Key string `json:"key" redis:",key"`
	Ver int64  `json:"ver" redis:",ver"`
	Val int64  `json:"val"`
}

func main() {
	c, err := rueidis.NewClient(rueidis.ClientOption{InitAddress: []string{"127.0.0.1:6377"}})
	if err != nil {
		panic(err)
	}
	defer c.Close()

	repo := om.NewJSONRepository("obj", obj{}, c)
	fmt.Println(repo.CreateIndex(context.Background(), func(schema om.FtCreateSchema) om.Completed {
		return schema.FieldName("$.val").As("val").Numeric().Build()
	}))

	records := make([]*obj, 100000)
	for i := range records {
		records[i] = repo.NewEntity()
		records[i].Val = int64(i)
	}
	for _, err = range repo.SaveMulti(context.Background(), records...) {
		if err != nil {
			panic(err)
		}
	}

	total, records, err := repo.Search(context.Background(), func(search om.FtSearchIndex) om.Completed {
		return search.Query("*").Sortby("val").Limit().OffsetNum(0, int64(len(records))).Build()
	})
	if err != nil {
		panic(err)
	}
	if total != int64(len(records)) {
		panic("total mismatch")
	}
	for i, r := range records {
		if r.Ver != 1 {
			panic("ver mismatch")
		}
		if r.Val != int64(i) {
			panic("val mismatch")
		}
	}
}


```