### PR TITLE
Add MaxFlushDelay option

### DIFF
--- a/pipe.go
+++ b/pipe.go
@@ -301,7 +301,7 @@ func (p *pipe) _backgroundWrite() (err error) {
 					} else {
 						ts := time.Now()
 						err = p.w.Flush()
-						time.Sleep(time.Microsecond*20 - time.Since(ts))
+						time.Sleep(p.maxFlushDelay - time.Since(ts))
 					}
 				}
 			}

--- a/pipe_test.go
+++ b/pipe_test.go
@@ -464,6 +464,26 @@ func TestWriteSinglePipelineFlush(t *testing.T) {
 	}
 }
 
+func TestWriteWithMaxFlushDelay(t *testing.T) {
+	p, mock, cancel, _ := setup(t, ClientOption{
+		AlwaysPipelining: true,
+		MaxFlushDelay:    20 * time.Microsecond,
+	})
+	defer cancel()
+	times := 2000
+	wg := sync.WaitGroup{}
+	wg.Add(times)
+
+	for i := 0; i < times; i++ {
+		go func() {
+			ExpectOK(t, p.Do(context.Background(), cmds.NewCompleted([]string{"PING"})))
+		}()
+	}
+	for i := 0; i < times; i++ {
+		mock.Expect("PING").ReplyString("OK")
+	}
+}
+
 func TestWriteMultiFlush(t *testing.T) {
 	p, mock, cancel, _ := setup(t, ClientOption{})
 	defer cancel()

--- a/rueidis.go
+++ b/rueidis.go
@@ -118,6 +118,14 @@ type ClientOption struct {
 	DisableCache bool
 	// AlwaysPipelining makes rueidis.Client always pipeline redis commands even if they are not issued concurrently.
 	AlwaysPipelining bool
+	// MaxFlushDelay when greater than zero pauses pipeline write loop for some time (not larger than MaxFlushDelay)
+	// after each flushing of data to the connection. This gives pipeline a chance to collect more commands to send
+	// to Redis. Adding this delay increases latency, reduces throughput – but in most cases may significantly reduce
+	// application and Redis CPU utilization due to less executed system calls. By default, Rueidis flushes data to the
+	// connection without extra delays. Depending on network latency and application-specific conditions the value
+	// of MaxFlushDelay may vary, sth like 20 microseconds should not affect latency/throughput a lot but still
+	// produce notable CPU usage reduction under load.
+	MaxFlushDelay time.Duration
 }
 
 // SentinelOption contains MasterSet,


### PR DESCRIPTION
Relates #156 

Adds `MaxFlushDelay` option to `rueidis.ClientOption`:

```go
// MaxFlushDelay when greater than zero pauses pipeline write loop for some time (not larger than MaxFlushDelay)
// after each flushing of data to the connection. This gives pipeline a chance to collect more commands to send
// to Redis. Adding this delay increases latency, reduces throughput – but in most cases may significantly reduce
// application and Redis CPU utilization due to less executed system calls. By default, Rueidis flushes data to the
// connection without extra delays. Depending on network latency and application-specific conditions the value
// of MaxFlushDelay may vary, sth like 20 microseconds should not affect latency/throughput a lot but still
// produce notable CPU usage reduction under load.
MaxFlushDelay time.Duration
```