### PR TITLE
feat: align rediscompat with go-redis v9, including

### DIFF
--- a/message.go
+++ b/message.go
@@ -305,6 +305,24 @@ func (r RedisResult) AsXRead() (v map[string][]XRangeEntry, err error) {
 	return
 }
 
+func (r RedisResult) AsLMPop() (v KeyValues, err error) {
+	if r.err != nil {
+		err = r.err
+	} else {
+		v, err = r.val.AsLMPop()
+	}
+	return
+}
+
+func (r RedisResult) AsZMPop() (v KeyZScores, err error) {
+	if r.err != nil {
+		err = r.err
+	} else {
+		v, err = r.val.AsZMPop()
+	}
+	return
+}
+
 // AsMap delegates to RedisMessage.AsMap
 func (r RedisResult) AsMap() (v map[string]RedisMessage, err error) {
 	if r.err != nil {
@@ -828,6 +846,44 @@ func (m *RedisMessage) AsIntMap() (map[string]int64, error) {
 	}
 	typ := m.typ
 	panic(fmt.Sprintf("redis message type %c is not a map/array/set or its length is not even", typ))
+}
+
+type KeyValues struct {
+	Key    string
+	Values []string
+}
+
+func (m *RedisMessage) AsLMPop() (kvs KeyValues, err error) {
+	if err = m.Error(); err != nil {
+		return KeyValues{}, err
+	}
+	if len(m.values) >= 2 {
+		kvs.Key = m.values[0].string
+		if kvs.Values, err = m.values[1].AsStrSlice(); err == nil {
+			return
+		}
+	}
+	typ := m.typ
+	panic(fmt.Sprintf("redis message type %c is not a RESP array", typ))
+}
+
+type KeyZScores struct {
+	Key    string
+	Values []ZScore
+}
+
+func (m *RedisMessage) AsZMPop() (kvs KeyZScores, err error) {
+	if err = m.Error(); err != nil {
+		return KeyZScores{}, err
+	}
+	if len(m.values) >= 2 {
+		kvs.Key = m.values[0].string
+		if kvs.Values, err = m.values[1].AsZScores(); err == nil {
+			return
+		}
+	}
+	typ := m.typ
+	panic(fmt.Sprintf("redis message type %c is not a RESP array", typ))
 }
 
 // ToMap check if message is a redis RESP3 map response, and return it

--- a/message.go
+++ b/message.go
@@ -859,12 +859,11 @@ func (m *RedisMessage) AsLMPop() (kvs KeyValues, err error) {
 	}
 	if len(m.values) >= 2 {
 		kvs.Key = m.values[0].string
-		if kvs.Values, err = m.values[1].AsStrSlice(); err == nil {
-			return
-		}
+		kvs.Values, err = m.values[1].AsStrSlice()
+		return
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a RESP array", typ))
+	panic(fmt.Sprintf("redis message type %c is not a LMPOP response", typ))
 }
 
 type KeyZScores struct {
@@ -878,12 +877,11 @@ func (m *RedisMessage) AsZMPop() (kvs KeyZScores, err error) {
 	}
 	if len(m.values) >= 2 {
 		kvs.Key = m.values[0].string
-		if kvs.Values, err = m.values[1].AsZScores(); err == nil {
-			return
-		}
+		kvs.Values, err = m.values[1].AsZScores()
+		return
 	}
 	typ := m.typ
-	panic(fmt.Sprintf("redis message type %c is not a RESP array", typ))
+	panic(fmt.Sprintf("redis message type %c is not a ZMPOP response", typ))
 }
 
 // ToMap check if message is a redis RESP3 map response, and return it

--- a/rueidiscompat/adapter.go
+++ b/rueidiscompat/adapter.go
@@ -1104,7 +1104,7 @@ func (c *Compat) BLMPop(ctx context.Context, timeout time.Duration, direction st
 	if count > 0 {
 		cmd = cmd.Args("COUNT", strconv.FormatInt(count, 10))
 	}
-	return newKeyValuesCmd(c.client.Do(ctx, cmd.Build()))
+	return newKeyValuesCmd(c.client.Do(ctx, cmd.Blocking()))
 }
 
 func (c *Compat) BRPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd {
@@ -1690,7 +1690,7 @@ func (c *Compat) BZMPop(ctx context.Context, timeout time.Duration, order string
 	if count > 0 {
 		cmd = cmd.Args("COUNT", strconv.FormatInt(count, 10))
 	}
-	return newZSliceWithKeyCmd(c.client.Do(ctx, cmd.Build()))
+	return newZSliceWithKeyCmd(c.client.Do(ctx, cmd.Blocking()))
 }
 
 // ZAdd Redis `ZADD key score member [score member ...]` command.

--- a/rueidiscompat/adapter.go
+++ b/rueidiscompat/adapter.go
@@ -2901,8 +2901,8 @@ func (c CacheCompat) SMembers(ctx context.Context, key string) *StringSliceCmd {
 	return newStringSliceCmd(resp)
 }
 
-func (c CacheCompat) Sort(ctx context.Context, key string, sort Sort) *StringSliceCmd {
-	cmd := c.client.B().Arbitrary("SORT").Keys(key)
+func (c CacheCompat) SortRO(ctx context.Context, key string, sort Sort) *StringSliceCmd {
+	cmd := c.client.B().Arbitrary("SORT_RO").Keys(key)
 	if sort.By != "" {
 		cmd = cmd.Args("BY", sort.By)
 	}

--- a/rueidiscompat/adapter.go
+++ b/rueidiscompat/adapter.go
@@ -57,6 +57,7 @@ type Cmdable interface {
 	Exists(ctx context.Context, keys ...string) *IntCmd
 	Expire(ctx context.Context, key string, expiration time.Duration) *BoolCmd
 	ExpireAt(ctx context.Context, key string, tm time.Time) *BoolCmd
+	ExpireTime(ctx context.Context, key string) *DurationCmd
 	ExpireNX(ctx context.Context, key string, expiration time.Duration) *BoolCmd
 	ExpireXX(ctx context.Context, key string, expiration time.Duration) *BoolCmd
 	ExpireGT(ctx context.Context, key string, expiration time.Duration) *BoolCmd
@@ -70,6 +71,7 @@ type Cmdable interface {
 	Persist(ctx context.Context, key string) *BoolCmd
 	PExpire(ctx context.Context, key string, expiration time.Duration) *BoolCmd
 	PExpireAt(ctx context.Context, key string, tm time.Time) *BoolCmd
+	PExpireTime(ctx context.Context, key string) *DurationCmd
 	PTTL(ctx context.Context, key string) *DurationCmd
 	RandomKey(ctx context.Context) *StringCmd
 	Rename(ctx context.Context, key, newkey string) *StatusCmd
@@ -77,6 +79,7 @@ type Cmdable interface {
 	Restore(ctx context.Context, key string, ttl time.Duration, value string) *StatusCmd
 	RestoreReplace(ctx context.Context, key string, ttl time.Duration, value string) *StatusCmd
 	Sort(ctx context.Context, key string, sort Sort) *StringSliceCmd
+	SortRO(ctx context.Context, key string, sort Sort) *StringSliceCmd
 	SortStore(ctx context.Context, key, store string, sort Sort) *IntCmd
 	SortInterfaces(ctx context.Context, key string, sort Sort) *SliceCmd
 	Touch(ctx context.Context, keys ...string) *IntCmd
@@ -134,9 +137,11 @@ type Cmdable interface {
 	HMSet(ctx context.Context, key string, values ...any) *BoolCmd
 	HSetNX(ctx context.Context, key, field string, value any) *BoolCmd
 	HVals(ctx context.Context, key string) *StringSliceCmd
-	HRandField(ctx context.Context, key string, count int64, withValues bool) *StringSliceCmd
+	HRandField(ctx context.Context, key string, count int64) *StringSliceCmd
+	HRandFieldWithValues(ctx context.Context, key string, count int64) *KeyValueSliceCmd
 
 	BLPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd
+	BLMPop(ctx context.Context, timeout time.Duration, direction string, count int64, keys ...string) *KeyValuesCmd
 	BRPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd
 	BRPopLPush(ctx context.Context, source, destination string, timeout time.Duration) *StringCmd
 	LIndex(ctx context.Context, key string, index int64) *StringCmd
@@ -144,6 +149,7 @@ type Cmdable interface {
 	LInsertBefore(ctx context.Context, key string, pivot, value any) *IntCmd
 	LInsertAfter(ctx context.Context, key string, pivot, value any) *IntCmd
 	LLen(ctx context.Context, key string) *IntCmd
+	LMPop(ctx context.Context, direction string, count int64, keys ...string) *KeyValuesCmd
 	LPop(ctx context.Context, key string) *StringCmd
 	LPopCount(ctx context.Context, key string, count int64) *StringSliceCmd
 	LPos(ctx context.Context, key string, value string, args LPosArgs) *IntCmd
@@ -167,6 +173,7 @@ type Cmdable interface {
 	SDiff(ctx context.Context, keys ...string) *StringSliceCmd
 	SDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd
 	SInter(ctx context.Context, keys ...string) *StringSliceCmd
+	SInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd
 	SInterStore(ctx context.Context, destination string, keys ...string) *IntCmd
 	SIsMember(ctx context.Context, key string, member any) *BoolCmd
 	SMIsMember(ctx context.Context, key string, members ...any) *BoolSliceCmd
@@ -204,7 +211,6 @@ type Cmdable interface {
 	XClaimJustID(ctx context.Context, a XClaimArgs) *StringSliceCmd
 	XAutoClaim(ctx context.Context, a XAutoClaimArgs) *XAutoClaimCmd
 	XAutoClaimJustID(ctx context.Context, a XAutoClaimArgs) *XAutoClaimJustIDCmd
-
 	XTrimMaxLen(ctx context.Context, key string, maxLen int64) *IntCmd
 	XTrimMaxLenApprox(ctx context.Context, key string, maxLen, limit int64) *IntCmd
 	XTrimMinID(ctx context.Context, key string, minID string) *IntCmd
@@ -216,19 +222,24 @@ type Cmdable interface {
 
 	BZPopMax(ctx context.Context, timeout time.Duration, keys ...string) *ZWithKeyCmd
 	BZPopMin(ctx context.Context, timeout time.Duration, keys ...string) *ZWithKeyCmd
+	BZMPop(ctx context.Context, timeout time.Duration, order string, count int64, keys ...string) *ZSliceWithKeyCmd
 
 	ZAdd(ctx context.Context, key string, members ...Z) *IntCmd
+	ZAddLT(ctx context.Context, key string, members ...Z) *IntCmd
+	ZAddGT(ctx context.Context, key string, members ...Z) *IntCmd
 	ZAddNX(ctx context.Context, key string, members ...Z) *IntCmd
 	ZAddXX(ctx context.Context, key string, members ...Z) *IntCmd
 	ZAddArgs(ctx context.Context, key string, args ZAddArgs) *IntCmd
 	ZAddArgsIncr(ctx context.Context, key string, args ZAddArgs) *FloatCmd
 	ZCard(ctx context.Context, key string) *IntCmd
-	ZCount(ctx context.Context, key string, min, max string) *IntCmd
+	ZCount(ctx context.Context, key, min, max string) *IntCmd
 	ZLexCount(ctx context.Context, key, min, max string) *IntCmd
 	ZIncrBy(ctx context.Context, key string, increment float64, member string) *FloatCmd
 	ZInter(ctx context.Context, store ZStore) *StringSliceCmd
 	ZInterWithScores(ctx context.Context, store ZStore) *ZSliceCmd
+	ZInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd
 	ZInterStore(ctx context.Context, destination string, store ZStore) *IntCmd
+	ZMPop(ctx context.Context, order string, count int64, keys ...string) *ZSliceWithKeyCmd
 	ZMScore(ctx context.Context, key string, members ...string) *FloatSliceCmd
 	ZPopMax(ctx context.Context, key string, count ...int64) *ZSliceCmd
 	ZPopMin(ctx context.Context, key string, count ...int64) *ZSliceCmd
@@ -243,7 +254,7 @@ type Cmdable interface {
 	ZRank(ctx context.Context, key, member string) *IntCmd
 	ZRem(ctx context.Context, key string, members ...any) *IntCmd
 	ZRemRangeByRank(ctx context.Context, key string, start, stop int64) *IntCmd
-	ZRemRangeByScore(ctx context.Context, key string, min, max string) *IntCmd
+	ZRemRangeByScore(ctx context.Context, key, min, max string) *IntCmd
 	ZRemRangeByLex(ctx context.Context, key, min, max string) *IntCmd
 	ZRevRange(ctx context.Context, key string, start, stop int64) *StringSliceCmd
 	ZRevRangeWithScores(ctx context.Context, key string, start, stop int64) *ZSliceCmd
@@ -253,10 +264,10 @@ type Cmdable interface {
 	ZRevRank(ctx context.Context, key, member string) *IntCmd
 	ZScore(ctx context.Context, key, member string) *FloatCmd
 	ZUnionStore(ctx context.Context, dest string, store ZStore) *IntCmd
-	ZUnion(ctx context.Context, store ZStore) *StringSliceCmd
-	ZUnionWithScores(ctx context.Context, store ZStore) *ZSliceCmd
 	ZRandMember(ctx context.Context, key string, count int64) *StringSliceCmd
 	ZRandMemberWithScores(ctx context.Context, key string, count int64) *ZSliceCmd
+	ZUnion(ctx context.Context, store ZStore) *StringSliceCmd
+	ZUnionWithScores(ctx context.Context, store ZStore) *ZSliceCmd
 	ZDiff(ctx context.Context, keys ...string) *StringSliceCmd
 	ZDiffWithScores(ctx context.Context, keys ...string) *ZSliceCmd
 	ZDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd
@@ -273,6 +284,8 @@ type Cmdable interface {
 	ClientPause(ctx context.Context, dur time.Duration) *BoolCmd
 	ClientUnpause(ctx context.Context) *BoolCmd
 	ClientID(ctx context.Context) *IntCmd
+	ClientUnblock(ctx context.Context, id int64) *IntCmd
+	ClientUnblockWithError(ctx context.Context, id int64) *IntCmd
 	ConfigGet(ctx context.Context, parameter string) *SliceCmd
 	ConfigResetStat(ctx context.Context) *StatusCmd
 	ConfigSet(ctx context.Context, parameter, value string) *StatusCmd
@@ -288,7 +301,7 @@ type Cmdable interface {
 	Shutdown(ctx context.Context) *StatusCmd
 	ShutdownSave(ctx context.Context) *StatusCmd
 	ShutdownNoSave(ctx context.Context) *StatusCmd
-	SlaveOf(ctx context.Context, host string, port string) *StatusCmd
+	SlaveOf(ctx context.Context, host, port string) *StatusCmd
 	Time(ctx context.Context) *TimeCmd
 	DebugObject(ctx context.Context, key string) *StringCmd
 	ReadOnly(ctx context.Context) *StatusCmd
@@ -297,15 +310,20 @@ type Cmdable interface {
 
 	Eval(ctx context.Context, script string, keys []string, args ...any) *Cmd
 	EvalSha(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd
+	EvalRO(ctx context.Context, script string, keys []string, args ...any) *Cmd
+	EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd
 	ScriptExists(ctx context.Context, hashes ...string) *BoolSliceCmd
 	ScriptFlush(ctx context.Context) *StatusCmd
 	ScriptKill(ctx context.Context) *StatusCmd
 	ScriptLoad(ctx context.Context, script string) *StringCmd
 
 	Publish(ctx context.Context, channel string, message any) *IntCmd
+	SPublish(ctx context.Context, channel string, message any) *IntCmd
 	PubSubChannels(ctx context.Context, pattern string) *StringSliceCmd
 	PubSubNumSub(ctx context.Context, channels ...string) *StringIntMapCmd
 	PubSubNumPat(ctx context.Context) *IntCmd
+	PubSubShardChannels(ctx context.Context, pattern string) *StringSliceCmd
+	PubSubShardNumSub(ctx context.Context, channels ...string) *StringIntMapCmd
 
 	ClusterSlots(ctx context.Context) *ClusterSlotsCmd
 	ClusterNodes(ctx context.Context) *StringCmd
@@ -335,7 +353,7 @@ type Cmdable interface {
 	GeoRadiusByMemberStore(ctx context.Context, key, member string, query GeoRadiusQuery) *IntCmd
 	GeoSearch(ctx context.Context, key string, q GeoSearchQuery) *StringSliceCmd
 	GeoSearchLocation(ctx context.Context, key string, q GeoSearchLocationQuery) *GeoLocationCmd
-	GeoSearchStore(ctx context.Context, src, dest string, q GeoSearchStoreQuery) *IntCmd
+	GeoSearchStore(ctx context.Context, key, store string, q GeoSearchStoreQuery) *IntCmd
 	GeoDist(ctx context.Context, key, member1, member2, unit string) *FloatCmd
 	GeoHash(ctx context.Context, key string, members ...string) *StringSliceCmd
 }
@@ -421,6 +439,11 @@ func (c *Compat) ExpireAt(ctx context.Context, key string, timestamp time.Time) 
 	cmd := c.client.B().Expireat().Key(key).Timestamp(timestamp.Unix()).Build()
 	resp := c.client.Do(ctx, cmd)
 	return newBoolCmd(resp)
+}
+func (c *Compat) ExpireTime(ctx context.Context, key string) *DurationCmd {
+	cmd := c.client.B().Expiretime().Key(key).Build()
+	resp := c.client.Do(ctx, cmd)
+	return newDurationCmd(resp, time.Second)
 }
 
 func (c *Compat) ExpireNX(ctx context.Context, key string, seconds time.Duration) *BoolCmd {
@@ -510,6 +533,12 @@ func (c *Compat) PExpireAt(ctx context.Context, key string, millisecondsTimestam
 	return newBoolCmd(resp)
 }
 
+func (c *Compat) PExpireTime(ctx context.Context, key string) *DurationCmd {
+	cmd := c.client.B().Pexpiretime().Key(key).Build()
+	resp := c.client.Do(ctx, cmd)
+	return newDurationCmd(resp, time.Millisecond)
+}
+
 func (c *Compat) PTTL(ctx context.Context, key string) *DurationCmd {
 	cmd := c.client.B().Pttl().Key(key).Build()
 	resp := c.client.Do(ctx, cmd)
@@ -546,8 +575,8 @@ func (c *Compat) RestoreReplace(ctx context.Context, key string, ttl time.Durati
 	return newStatusCmd(resp)
 }
 
-func (c *Compat) sort(key string, sort Sort) cmds.Arbitrary {
-	cmd := c.client.B().Arbitrary("SORT").Keys(key)
+func (c *Compat) sort(command, key string, sort Sort) cmds.Arbitrary {
+	cmd := c.client.B().Arbitrary(command).Keys(key)
 	if sort.By != "" {
 		cmd = cmd.Args("BY", sort.By)
 	}
@@ -571,17 +600,22 @@ func (c *Compat) sort(key string, sort Sort) cmds.Arbitrary {
 }
 
 func (c *Compat) Sort(ctx context.Context, key string, sort Sort) *StringSliceCmd {
-	resp := c.client.Do(ctx, c.sort(key, sort).Build())
+	resp := c.client.Do(ctx, c.sort("SORT", key, sort).Build())
+	return newStringSliceCmd(resp)
+}
+
+func (c *Compat) SortRO(ctx context.Context, key string, sort Sort) *StringSliceCmd {
+	resp := c.client.Do(ctx, c.sort("SORT_RO", key, sort).Build())
 	return newStringSliceCmd(resp)
 }
 
 func (c *Compat) SortStore(ctx context.Context, key, store string, sort Sort) *IntCmd {
-	resp := c.client.Do(ctx, c.sort(key, sort).Args("STORE", store).Build())
+	resp := c.client.Do(ctx, c.sort("SORT", key, sort).Args("STORE", store).Build())
 	return newIntCmd(resp)
 }
 
 func (c *Compat) SortInterfaces(ctx context.Context, key string, sort Sort) *SliceCmd {
-	resp := c.client.Do(ctx, c.sort(key, sort).Build())
+	resp := c.client.Do(ctx, c.sort("SORT", key, sort).Build())
 	return newSliceCmd(resp)
 }
 
@@ -1050,21 +1084,27 @@ func (c *Compat) HVals(ctx context.Context, key string) *StringSliceCmd {
 	return newStringSliceCmd(resp)
 }
 
-func (c *Compat) HRandField(ctx context.Context, key string, count int64, withValues bool) *StringSliceCmd {
-	var resp rueidis.RedisResult
-	if withValues {
-		resp = c.client.Do(ctx, c.client.B().Hrandfield().Key(key).Count(count).Withvalues().Build())
-		return flattenStringSliceCmd(resp)
-	} else {
-		resp = c.client.Do(ctx, c.client.B().Hrandfield().Key(key).Count(count).Build())
-		return newStringSliceCmd(resp)
-	}
+func (c *Compat) HRandField(ctx context.Context, key string, count int64) *StringSliceCmd {
+	return newStringSliceCmd(c.client.Do(ctx, c.client.B().Hrandfield().Key(key).Count(count).Build()))
+}
+
+func (c *Compat) HRandFieldWithValues(ctx context.Context, key string, count int64) *KeyValueSliceCmd {
+	return newKeyValueSliceCmd(c.client.Do(ctx, c.client.B().Hrandfield().Key(key).Count(count).Withvalues().Build()))
 }
 
 func (c *Compat) BLPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd {
 	cmd := c.client.B().Blpop().Key(keys...).Timeout(float64(formatSec(timeout))).Build()
 	resp := c.client.Do(ctx, cmd)
 	return newStringSliceCmd(resp)
+}
+
+func (c *Compat) BLMPop(ctx context.Context, timeout time.Duration, direction string, count int64, keys ...string) *KeyValuesCmd {
+	cmd := c.client.B().Arbitrary("BLMPOP", strconv.FormatInt(formatSec(timeout), 10), strconv.Itoa(len(keys))).Keys(keys...)
+	cmd = cmd.Args(direction)
+	if count > 0 {
+		cmd = cmd.Args("COUNT", strconv.FormatInt(count, 10))
+	}
+	return newKeyValuesCmd(c.client.Do(ctx, cmd.Build()))
 }
 
 func (c *Compat) BRPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd {
@@ -1114,6 +1154,15 @@ func (c *Compat) LLen(ctx context.Context, key string) *IntCmd {
 	cmd := c.client.B().Llen().Key(key).Build()
 	resp := c.client.Do(ctx, cmd)
 	return newIntCmd(resp)
+}
+
+func (c *Compat) LMPop(ctx context.Context, direction string, count int64, keys ...string) *KeyValuesCmd {
+	cmd := c.client.B().Arbitrary("LMPOP", strconv.Itoa(len(keys))).Keys(keys...)
+	cmd = cmd.Args(direction)
+	if count > 0 {
+		cmd = cmd.Args("COUNT", strconv.FormatInt(count, 10))
+	}
+	return newKeyValuesCmd(c.client.Do(ctx, cmd.Build()))
 }
 
 func (c *Compat) LPop(ctx context.Context, key string) *StringCmd {
@@ -1259,6 +1308,10 @@ func (c *Compat) SInter(ctx context.Context, keys ...string) *StringSliceCmd {
 	cmd := c.client.B().Sinter().Key(keys...).Build()
 	resp := c.client.Do(ctx, cmd)
 	return newStringSliceCmd(resp)
+}
+
+func (c *Compat) SInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd {
+	return newIntCmd(c.client.Do(ctx, c.client.B().Sintercard().Numkeys(int64(len(keys))).Key(keys...).Limit(limit).Build()))
 }
 
 func (c *Compat) SInterStore(ctx context.Context, destination string, keys ...string) *IntCmd {
@@ -1631,34 +1684,36 @@ func (c *Compat) BZPopMin(ctx context.Context, timeout time.Duration, keys ...st
 	return newZWithKeyCmd(resp)
 }
 
+func (c *Compat) BZMPop(ctx context.Context, timeout time.Duration, order string, count int64, keys ...string) *ZSliceWithKeyCmd {
+	cmd := c.client.B().Arbitrary("BZMPOP", strconv.FormatInt(formatSec(timeout), 10), strconv.Itoa(len(keys))).Keys(keys...)
+	cmd = cmd.Args(order)
+	if count > 0 {
+		cmd = cmd.Args("COUNT", strconv.FormatInt(count, 10))
+	}
+	return newZSliceWithKeyCmd(c.client.Do(ctx, cmd.Build()))
+}
+
 // ZAdd Redis `ZADD key score member [score member ...]` command.
 func (c *Compat) ZAdd(ctx context.Context, key string, members ...Z) *IntCmd {
-	cmd := c.client.B().Zadd().Key(key).ScoreMember()
-	for _, v := range members {
-		cmd = cmd.ScoreMember(v.Score, str(v.Member))
-	}
-	resp := c.client.Do(ctx, cmd.Build())
-	return newIntCmd(resp)
+	return newIntCmd(c.zAddArgs(ctx, key, false, ZAddArgs{Members: members}))
 }
 
 // ZAddNX Redis `ZADD key NX score member [score member ...]` command.
 func (c *Compat) ZAddNX(ctx context.Context, key string, members ...Z) *IntCmd {
-	cmd := c.client.B().Zadd().Key(key).Nx().ScoreMember()
-	for _, v := range members {
-		cmd = cmd.ScoreMember(v.Score, str(v.Member))
-	}
-	resp := c.client.Do(ctx, cmd.Build())
-	return newIntCmd(resp)
+	return newIntCmd(c.zAddArgs(ctx, key, false, ZAddArgs{Members: members, NX: true}))
 }
 
 // ZAddXX Redis `ZADD key XX score member [score member ...]` command.
 func (c *Compat) ZAddXX(ctx context.Context, key string, members ...Z) *IntCmd {
-	cmd := c.client.B().Zadd().Key(key).Xx().ScoreMember()
-	for _, v := range members {
-		cmd = cmd.ScoreMember(v.Score, str(v.Member))
-	}
-	resp := c.client.Do(ctx, cmd.Build())
-	return newIntCmd(resp)
+	return newIntCmd(c.zAddArgs(ctx, key, false, ZAddArgs{Members: members, XX: true}))
+}
+
+func (c *Compat) ZAddLT(ctx context.Context, key string, members ...Z) *IntCmd {
+	return newIntCmd(c.zAddArgs(ctx, key, false, ZAddArgs{Members: members, LT: true}))
+}
+
+func (c *Compat) ZAddGT(ctx context.Context, key string, members ...Z) *IntCmd {
+	return newIntCmd(c.zAddArgs(ctx, key, false, ZAddArgs{Members: members, GT: true}))
 }
 
 func (c *Compat) zAddArgs(ctx context.Context, key string, incr bool, args ZAddArgs) rueidis.RedisResult {
@@ -1703,7 +1758,7 @@ func (c *Compat) ZCard(ctx context.Context, key string) *IntCmd {
 	return newIntCmd(resp)
 }
 
-func (c *Compat) ZCount(ctx context.Context, key string, min, max string) *IntCmd {
+func (c *Compat) ZCount(ctx context.Context, key, min, max string) *IntCmd {
 	cmd := c.client.B().Zcount().Key(key).Min(min).Max(max).Build()
 	resp := c.client.Do(ctx, cmd)
 	return newIntCmd(resp)
@@ -1743,8 +1798,21 @@ func (c *Compat) ZInterWithScores(ctx context.Context, store ZStore) *ZSliceCmd 
 	return newZSliceCmd(c.client.Do(ctx, zstore(c.client.B().Arbitrary("ZINTER"), store).Args("WITHSCORES").ReadOnly()))
 }
 
+func (c *Compat) ZInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd {
+	return newIntCmd(c.client.Do(ctx, c.client.B().Zintercard().Numkeys(int64(len(keys))).Key(keys...).Limit(limit).Build()))
+}
+
 func (c *Compat) ZInterStore(ctx context.Context, destination string, store ZStore) *IntCmd {
 	return newIntCmd(c.client.Do(ctx, zstore(c.client.B().Arbitrary("ZINTERSTORE").Keys(destination), store).Build()))
+}
+
+func (c *Compat) ZMPop(ctx context.Context, order string, count int64, keys ...string) *ZSliceWithKeyCmd {
+	cmd := c.client.B().Arbitrary("ZMPOP", strconv.Itoa(len(keys))).Keys(keys...)
+	cmd = cmd.Args(order)
+	if count > 0 {
+		cmd = cmd.Args("COUNT", strconv.FormatInt(count, 10))
+	}
+	return newZSliceWithKeyCmd(c.client.Do(ctx, cmd.Build()))
 }
 
 func (c *Compat) ZMScore(ctx context.Context, key string, members ...string) *FloatSliceCmd {
@@ -1910,7 +1978,7 @@ func (c *Compat) ZRemRangeByRank(ctx context.Context, key string, start, stop in
 	resp := c.client.Do(ctx, cmd)
 	return newIntCmd(resp)
 }
-func (c *Compat) ZRemRangeByScore(ctx context.Context, key string, min, max string) *IntCmd {
+func (c *Compat) ZRemRangeByScore(ctx context.Context, key, min, max string) *IntCmd {
 	cmd := c.client.B().Zremrangebyscore().Key(key).Min(min).Max(max).Build()
 	resp := c.client.Do(ctx, cmd)
 	return newIntCmd(resp)
@@ -2093,9 +2161,15 @@ func (c *Compat) ClientUnpause(ctx context.Context) *BoolCmd {
 }
 
 func (c *Compat) ClientID(ctx context.Context) *IntCmd {
-	cmd := c.client.B().ClientId().Build()
-	resp := c.client.Do(ctx, cmd)
-	return newIntCmd(resp)
+	return newIntCmd(c.client.Do(ctx, c.client.B().ClientId().Build()))
+}
+
+func (c *Compat) ClientUnblock(ctx context.Context, id int64) *IntCmd {
+	return newIntCmd(c.client.Do(ctx, c.client.B().ClientUnblock().ClientId(id).Build()))
+}
+
+func (c *Compat) ClientUnblockWithError(ctx context.Context, id int64) *IntCmd {
+	return newIntCmd(c.client.Do(ctx, c.client.B().ClientUnblock().ClientId(id).Error().Build()))
 }
 
 func (c *Compat) ConfigGet(ctx context.Context, parameter string) *SliceCmd {
@@ -2188,7 +2262,7 @@ func (c *Compat) ShutdownNoSave(ctx context.Context) *StatusCmd {
 	})
 }
 
-func (c *Compat) SlaveOf(ctx context.Context, host string, port string) *StatusCmd {
+func (c *Compat) SlaveOf(ctx context.Context, host, port string) *StatusCmd {
 	p, err := strconv.ParseInt(port, 10, 64)
 	if err != nil {
 		return &StatusCmd{err: err}
@@ -2242,6 +2316,16 @@ func (c *Compat) Eval(ctx context.Context, script string, keys []string, args ..
 
 func (c *Compat) EvalSha(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd {
 	cmd := c.client.B().Evalsha().Sha1(sha1).Numkeys(int64(len(keys))).Key(keys...).Arg(argsToSlice(args)...).Build()
+	return newCmd(c.client.Do(ctx, cmd))
+}
+
+func (c *Compat) EvalRO(ctx context.Context, script string, keys []string, args ...any) *Cmd {
+	cmd := c.client.B().EvalRo().Script(script).Numkeys(int64(len(keys))).Key(keys...).Arg(argsToSlice(args)...).Build()
+	return newCmd(c.client.Do(ctx, cmd))
+}
+
+func (c *Compat) EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd {
+	cmd := c.client.B().EvalshaRo().Sha1(sha1).Numkeys(int64(len(keys))).Key(keys...).Arg(argsToSlice(args)...).Build()
 	return newCmd(c.client.Do(ctx, cmd))
 }
 
@@ -2300,6 +2384,12 @@ func (c *Compat) Publish(ctx context.Context, channel string, message any) *IntC
 	return newIntCmd(resp)
 }
 
+func (c *Compat) SPublish(ctx context.Context, channel string, message any) *IntCmd {
+	cmd := c.client.B().Spublish().Channel(channel).Message(str(message)).Build()
+	resp := c.client.Do(ctx, cmd)
+	return newIntCmd(resp)
+}
+
 func (c *Compat) PubSubChannels(ctx context.Context, pattern string) *StringSliceCmd {
 	cmd := c.client.B().PubsubChannels().Pattern(pattern).Build()
 	resp := c.client.Do(ctx, cmd)
@@ -2316,6 +2406,18 @@ func (c *Compat) PubSubNumPat(ctx context.Context) *IntCmd {
 	cmd := c.client.B().PubsubNumpat().Build()
 	resp := c.client.Do(ctx, cmd)
 	return newIntCmd(resp)
+}
+
+func (c *Compat) PubSubShardChannels(ctx context.Context, pattern string) *StringSliceCmd {
+	cmd := c.client.B().PubsubShardchannels().Pattern(pattern).Build()
+	resp := c.client.Do(ctx, cmd)
+	return newStringSliceCmd(resp)
+}
+
+func (c *Compat) PubSubShardNumSub(ctx context.Context, channels ...string) *StringIntMapCmd {
+	cmd := c.client.B().PubsubShardnumsub().Channel(channels...).Build()
+	resp := c.client.Do(ctx, cmd)
+	return newStringIntMapCmd(resp)
 }
 
 func (c *Compat) ClusterSlots(ctx context.Context) *ClusterSlotsCmd {
@@ -2859,7 +2961,7 @@ func (c CacheCompat) ZCard(ctx context.Context, key string) *IntCmd {
 	return newIntCmd(resp)
 }
 
-func (c CacheCompat) ZCount(ctx context.Context, key string, min, max string) *IntCmd {
+func (c CacheCompat) ZCount(ctx context.Context, key, min, max string) *IntCmd {
 	cmd := c.client.B().Zcount().Key(key).Min(min).Max(max).Cache()
 	resp := c.client.DoCache(ctx, cmd, c.ttl)
 	return newIntCmd(resp)

--- a/rueidiscompat/adapter.go
+++ b/rueidiscompat/adapter.go
@@ -301,7 +301,6 @@ type Cmdable interface {
 	Shutdown(ctx context.Context) *StatusCmd
 	ShutdownSave(ctx context.Context) *StatusCmd
 	ShutdownNoSave(ctx context.Context) *StatusCmd
-	SlaveOf(ctx context.Context, host, port string) *StatusCmd
 	Time(ctx context.Context) *TimeCmd
 	DebugObject(ctx context.Context, key string) *StringCmd
 	ReadOnly(ctx context.Context) *StatusCmd
@@ -2260,16 +2259,6 @@ func (c *Compat) ShutdownNoSave(ctx context.Context) *StatusCmd {
 	return c.doStatusCmdPrimaries(ctx, func(c rueidis.Client) cmds.Completed {
 		return c.B().Shutdown().Nosave().Build()
 	})
-}
-
-func (c *Compat) SlaveOf(ctx context.Context, host, port string) *StatusCmd {
-	p, err := strconv.ParseInt(port, 10, 64)
-	if err != nil {
-		return &StatusCmd{err: err}
-	}
-	cmd := c.client.B().Slaveof().Host(host).Port(p).Build()
-	resp := c.client.Do(ctx, cmd)
-	return newStatusCmd(resp)
 }
 
 func (c *Compat) Time(ctx context.Context) *TimeCmd {

--- a/rueidiscompat/adapter_test.go
+++ b/rueidiscompat/adapter_test.go
@@ -2007,20 +2007,21 @@ func testAdapter(resp3 bool) {
 				err = adapter.HSet(ctx, "hash", "key2", "hello2").Err()
 				Expect(err).NotTo(HaveOccurred())
 
-				v := adapter.HRandField(ctx, "hash", 1, false)
+				v := adapter.HRandField(ctx, "hash", 1)
 				Expect(v.Err()).NotTo(HaveOccurred())
 				Expect(v.Val()).To(Or(Equal([]string{"key1"}), Equal([]string{"key2"})))
 
-				v = adapter.HRandField(ctx, "hash", 0, false)
+				v = adapter.HRandField(ctx, "hash", 0)
 				Expect(v.Err()).NotTo(HaveOccurred())
 				Expect(v.Val()).To(HaveLen(0))
 
-				v = adapter.HRandField(ctx, "hash", 2, true)
-				Expect(v.Err()).NotTo(HaveOccurred())
-				Expect(v.Val()).To(Or(
-					ContainElements("key1", "hello1", "key2", "hello2"),
-					ContainElements("key2", "hello2", "key1", "hello1"),
-				))
+				// TODO
+				//v = adapter.HRandFieldWithValues(ctx, "hash", 2)
+				//Expect(v.Err()).NotTo(HaveOccurred())
+				//Expect(v.Val()).To(Or(
+				//	ContainElements("key1", "hello1", "key2", "hello2"),
+				//	ContainElements("key2", "hello2", "key1", "hello1"),
+				//))
 
 				// TODO
 				//var slice []string

--- a/rueidiscompat/adapter_test.go
+++ b/rueidiscompat/adapter_test.go
@@ -508,6 +508,10 @@ func testAdapter(resp3 bool) {
 				Expect(timeCmd.Err()).NotTo(HaveOccurred())
 				Expect(timeCmd.Val().Seconds()).To(BeNumerically("==", expireAt.Unix()))
 
+				ptimeCmd := adapter.PExpireTime(ctx, "key")
+				Expect(ptimeCmd.Err()).NotTo(HaveOccurred())
+				Expect(ptimeCmd.Val().Seconds()).To(BeNumerically("==", expireAt.Unix()))
+
 				// Check correct expiration in the past
 				expireAtCmd = adapter.ExpireAt(ctx, "key", time.Now().Add(-time.Hour))
 				Expect(expireAtCmd.Err()).NotTo(HaveOccurred())
@@ -765,6 +769,53 @@ func testAdapter(resp3 bool) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(els).To(Equal([]string{"2", "3"}))
 		})
+
+		if resp3 {
+			It("should Sort", func() {
+				size, err := adapter.LPush(ctx, "list", "1").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(size).To(Equal(int64(1)))
+
+				size, err = adapter.LPush(ctx, "list", "3").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(size).To(Equal(int64(2)))
+
+				size, err = adapter.LPush(ctx, "list", "2").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(size).To(Equal(int64(3)))
+
+				els, err := adapter.SortRO(ctx, "list", Sort{
+					Offset: 0,
+					Count:  2,
+					Order:  "ASC",
+					Alpha:  true,
+				}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(els).To(Equal([]string{"1", "2"}))
+			})
+
+			It("should Sort By", func() {
+				size, err := adapter.LPush(ctx, "list_by", "1").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(size).To(Equal(int64(1)))
+
+				size, err = adapter.LPush(ctx, "list_by", "3").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(size).To(Equal(int64(2)))
+
+				size, err = adapter.LPush(ctx, "list_by", "2").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(size).To(Equal(int64(3)))
+
+				els, err := adapter.SortRO(ctx, "list_by", Sort{
+					Offset: 0,
+					Count:  2,
+					By:     "nosort",
+				}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(els).To(Equal([]string{"2", "3"}))
+			})
+		}
 
 		It("should Sort Panic", func() {
 			Expect(func() {
@@ -2028,19 +2079,12 @@ func testAdapter(resp3 bool) {
 				Expect(v.Err()).NotTo(HaveOccurred())
 				Expect(v.Val()).To(HaveLen(0))
 
-				// TODO
-				//v = adapter.HRandFieldWithValues(ctx, "hash", 2)
-				//Expect(v.Err()).NotTo(HaveOccurred())
-				//Expect(v.Val()).To(Or(
-				//	ContainElements("key1", "hello1", "key2", "hello2"),
-				//	ContainElements("key2", "hello2", "key1", "hello1"),
-				//))
-
-				// TODO
-				//var slice []string
-				//err = adapter.HRandField(ctx, "hash", 1, true).ScanSlice(&slice)
-				//Expect(err).NotTo(HaveOccurred())
-				//Expect(slice).To(Or(Equal([]string{"key1", "hello1"}), Equal([]string{"key2", "hello2"})))
+				kv, err := adapter.HRandFieldWithValues(ctx, "hash", -1).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(kv).To(Or(
+					Equal([]KeyValue{{Key: "key1", Value: "hello1"}}),
+					Equal([]KeyValue{{Key: "key2", Value: "hello2"}}),
+				))
 			})
 		}
 	})
@@ -2246,6 +2290,46 @@ func testAdapter(resp3 bool) {
 		})
 
 		if resp3 {
+			It("should LMPop", func() {
+				err := adapter.LPush(ctx, "list1", "one", "two", "three", "four", "five").Err()
+				Expect(err).NotTo(HaveOccurred())
+
+				err = adapter.LPush(ctx, "list2", "a", "b", "c", "d", "e").Err()
+				Expect(err).NotTo(HaveOccurred())
+
+				key, val, err := adapter.LMPop(ctx, "left", 3, "list1", "list2").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(key).To(Equal("list1"))
+				Expect(val).To(Equal([]string{"five", "four", "three"}))
+
+				key, val, err = adapter.LMPop(ctx, "right", 3, "list1", "list2").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(key).To(Equal("list1"))
+				Expect(val).To(Equal([]string{"one", "two"}))
+
+				key, val, err = adapter.LMPop(ctx, "left", 1, "list1", "list2").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(key).To(Equal("list2"))
+				Expect(val).To(Equal([]string{"e"}))
+
+				key, val, err = adapter.LMPop(ctx, "right", 10, "list1", "list2").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(key).To(Equal("list2"))
+				Expect(val).To(Equal([]string{"a", "b", "c", "d"}))
+
+				err = adapter.LMPop(ctx, "left", 10, "list1", "list2").Err()
+				Expect(err).To(Equal(rueidis.Nil))
+
+				err = adapter.Set(ctx, "list3", 1024, 0).Err()
+				Expect(err).NotTo(HaveOccurred())
+
+				err = adapter.LMPop(ctx, "left", 10, "list1", "list2", "list3").Err()
+				Expect(err.Error()).To(Equal("WRONGTYPE Operation against a key holding the wrong kind of value"))
+
+				err = adapter.LMPop(ctx, "right", 0, "list1", "list2").Err()
+				Expect(err).To(HaveOccurred())
+			})
+
 			It("should BLMPop", func() {
 				err := adapter.LPush(ctx, "list1", "one", "two", "three", "four", "five").Err()
 				Expect(err).NotTo(HaveOccurred())
@@ -2804,6 +2888,38 @@ func testAdapter(resp3 bool) {
 			Expect(sInter.Err()).NotTo(HaveOccurred())
 			Expect(sInter.Val()).To(Equal([]string{"c"}))
 		})
+
+		if resp3 {
+			It("should SInterCard", func() {
+				sAdd := adapter.SAdd(ctx, "set1", "a")
+				Expect(sAdd.Err()).NotTo(HaveOccurred())
+				sAdd = adapter.SAdd(ctx, "set1", "b")
+				Expect(sAdd.Err()).NotTo(HaveOccurred())
+				sAdd = adapter.SAdd(ctx, "set1", "c")
+				Expect(sAdd.Err()).NotTo(HaveOccurred())
+
+				sAdd = adapter.SAdd(ctx, "set2", "b")
+				Expect(sAdd.Err()).NotTo(HaveOccurred())
+				sAdd = adapter.SAdd(ctx, "set2", "c")
+				Expect(sAdd.Err()).NotTo(HaveOccurred())
+				sAdd = adapter.SAdd(ctx, "set2", "d")
+				Expect(sAdd.Err()).NotTo(HaveOccurred())
+				sAdd = adapter.SAdd(ctx, "set2", "e")
+				Expect(sAdd.Err()).NotTo(HaveOccurred())
+				// limit 0 means no limit,see https://redis.io/commands/sintercard/ for more details
+				sInterCard := adapter.SInterCard(ctx, 0, "set1", "set2")
+				Expect(sInterCard.Err()).NotTo(HaveOccurred())
+				Expect(sInterCard.Val()).To(Equal(int64(2)))
+
+				sInterCard = adapter.SInterCard(ctx, 1, "set1", "set2")
+				Expect(sInterCard.Err()).NotTo(HaveOccurred())
+				Expect(sInterCard.Val()).To(Equal(int64(1)))
+
+				sInterCard = adapter.SInterCard(ctx, 3, "set1", "set2")
+				Expect(sInterCard.Err()).NotTo(HaveOccurred())
+				Expect(sInterCard.Val()).To(Equal(int64(2)))
+			})
+		}
 
 		It("should SInterStore", func() {
 			sAdd := adapter.SAdd(ctx, "set1", "a")
@@ -4526,6 +4642,32 @@ func testAdapter(resp3 bool) {
 				Expect(v).To(Equal([]string{"one", "two"}))
 			})
 
+			It("should ZInterCard", func() {
+				err := adapter.ZAdd(ctx, "zset1", Z{Score: 1, Member: "one"}).Err()
+				Expect(err).NotTo(HaveOccurred())
+				err = adapter.ZAdd(ctx, "zset1", Z{Score: 2, Member: "two"}).Err()
+				Expect(err).NotTo(HaveOccurred())
+				err = adapter.ZAdd(ctx, "zset2", Z{Score: 1, Member: "one"}).Err()
+				Expect(err).NotTo(HaveOccurred())
+				err = adapter.ZAdd(ctx, "zset2", Z{Score: 2, Member: "two"}).Err()
+				Expect(err).NotTo(HaveOccurred())
+				err = adapter.ZAdd(ctx, "zset2", Z{Score: 3, Member: "three"}).Err()
+				Expect(err).NotTo(HaveOccurred())
+
+				// limit 0 means no limit
+				sInterCard := adapter.ZInterCard(ctx, 0, "zset1", "zset2")
+				Expect(sInterCard.Err()).NotTo(HaveOccurred())
+				Expect(sInterCard.Val()).To(Equal(int64(2)))
+
+				sInterCard = adapter.ZInterCard(ctx, 1, "zset1", "zset2")
+				Expect(sInterCard.Err()).NotTo(HaveOccurred())
+				Expect(sInterCard.Val()).To(Equal(int64(1)))
+
+				sInterCard = adapter.ZInterCard(ctx, 3, "zset1", "zset2")
+				Expect(sInterCard.Err()).NotTo(HaveOccurred())
+				Expect(sInterCard.Val()).To(Equal(int64(2)))
+			})
+
 			It("should ZInterWithScores", func() {
 				err := adapter.ZAdd(ctx, "zset1", Z{Score: 1, Member: "one"}).Err()
 				Expect(err).NotTo(HaveOccurred())
@@ -5562,6 +5704,15 @@ func testAdapter(resp3 bool) {
 			Expect(res[1].GeoHash).To(Equal(int64(3479099956230698)))
 			Expect(res[1].Longitude).To(Equal(13.361389338970184))
 			Expect(res[1].Latitude).To(Equal(38.115556395496299))
+
+			ress, err := adapter.GeoRadiusByMemberStore(ctx, "Sicily", "Catania", GeoRadiusQuery{
+				Radius: 200,
+				Unit:   "km",
+				Count:  2,
+				Store:  "Sicily2",
+			}).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ress).To(Equal(int64(2)))
 		})
 
 		It("should search geo radius with no results", func() {
@@ -5917,6 +6068,26 @@ func testAdapter(resp3 bool) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(v).To(Equal(map[string]int64{"ch": 0}))
 		})
+
+		if resp3 {
+			It("SPublish", func() {
+				v, err := adapter.SPublish(ctx, "ch", "1").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(v).To(Equal(int64(0)))
+			})
+
+			It("PubSubShardChannels", func() {
+				v, err := adapter.PubSubShardChannels(ctx, "*").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(v).To(Equal([]string{}))
+			})
+
+			It("PubSubShardNumSub", func() {
+				v, err := adapter.PubSubShardNumSub(ctx, "ch").Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(v).To(Equal(map[string]int64{"ch": 0}))
+			})
+		}
 	})
 
 	Describe("Script", func() {
@@ -5962,6 +6133,28 @@ func testAdapter(resp3 bool) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vals).To(Equal([]any{"key", "hello"}))
 		})
+
+		if resp3 {
+			It("script load", func() {
+				val, err := adapter.ScriptLoad(
+					ctx,
+					"return {KEYS[1],ARGV[1]}",
+				).Result()
+				Expect(err).NotTo(HaveOccurred())
+				ret, err := adapter.ScriptExists(ctx, val).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ret).To(Equal([]bool{true}))
+
+				valsRo, err := adapter.EvalShaRO(
+					ctx,
+					val,
+					[]string{"key"},
+					"hello",
+				).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(valsRo).To(Equal([]any{"key", "hello"}))
+			})
+		}
 
 		It("script kill & flush", func() {
 			Expect(adapter.ScriptKill(ctx).Err()).To(MatchError("NOTBUSY No scripts in execution right now."))
@@ -6010,11 +6203,51 @@ func testAdapterCache(resp3 bool) {
 	})
 
 	Describe("Client", func() {
+		It("should ClientUnblock", func() {
+			id := adapter.ClientID(ctx).Val()
+			r, err := adapter.ClientUnblock(ctx, id).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(r).To(Equal(int64(0)))
+		})
+
+		It("should ClientUnblockWithError", func() {
+			id := adapter.ClientID(ctx).Val()
+			r, err := adapter.ClientUnblockWithError(ctx, id).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(r).To(Equal(int64(0)))
+		})
+
 		It("ClientPause", func() {
 			Expect(adapter.ClientPause(ctx, time.Second).Err()).NotTo(HaveOccurred())
 		})
+
 		It("ClientUnpause", func() {
 			Expect(adapter.ClientUnpause(ctx).Err()).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("EvalRO", func() {
+		It("returns keys and values", func() {
+			vals, err := adapter.EvalRO(
+				ctx,
+				"return {KEYS[1],ARGV[1]}",
+				[]string{"key"},
+				"hello",
+			).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vals).To(Equal([]any{"key", "hello"}))
+		})
+
+		It("returns all values after an error", func() {
+			vals, err := adapter.EvalRO(
+				ctx,
+				`return {12, {err="error"}, "abc"}`,
+				nil,
+			).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vals.([]any)[0]).To(Equal(int64(12)))
+			Expect(vals.([]any)[1].(error).Error()).To(Equal("error"))
+			Expect(vals.([]any)[2]).To(Equal("abc"))
 		})
 	})
 

--- a/rueidiscompat/adapter_test.go
+++ b/rueidiscompat/adapter_test.go
@@ -6336,7 +6336,7 @@ func testAdapterCache(resp3 bool) {
 
 		It("should Sort", func() {
 			Expect(func() {
-				adapter.Cache(time.Hour).Sort(ctx, "list", Sort{
+				adapter.Cache(time.Hour).SortRO(ctx, "list", Sort{
 					Order: "PANIC",
 				})
 			}).To(Panic())
@@ -6355,7 +6355,7 @@ func testAdapterCache(resp3 bool) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(size).To(Equal(int64(3)))
 
-			els, err := adapter.Cache(time.Hour).Sort(ctx, "list", Sort{
+			els, err := adapter.Cache(time.Hour).SortRO(ctx, "list", Sort{
 				Offset: 0,
 				Count:  2,
 				Order:  "ASC",
@@ -6378,7 +6378,7 @@ func testAdapterCache(resp3 bool) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(size).To(Equal(int64(3)))
 
-			els, err := adapter.Cache(time.Hour).Sort(ctx, "list_by", Sort{
+			els, err := adapter.Cache(time.Hour).SortRO(ctx, "list_by", Sort{
 				Offset: 0,
 				Count:  2,
 				By:     "nosort",
@@ -6404,7 +6404,7 @@ func testAdapterCache(resp3 bool) {
 			Expect(err).NotTo(HaveOccurred())
 
 			{
-				els, err := adapter.Cache(time.Hour).Sort(ctx, "list", Sort{
+				els, err := adapter.Cache(time.Hour).SortRO(ctx, "list", Sort{
 					Get: []string{"object_*"},
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())

--- a/rueidiscompat/command.go
+++ b/rueidiscompat/command.go
@@ -587,22 +587,6 @@ func newStringSliceCmd(res rueidis.RedisResult) *StringSliceCmd {
 	return &StringSliceCmd{val: val, err: err}
 }
 
-func flattenStringSliceCmd(res rueidis.RedisResult) *StringSliceCmd {
-	arr, err := res.ToArray()
-	if err != nil {
-		return &StringSliceCmd{err: err}
-	}
-	val := make([]string, 0, len(arr)*2)
-	for _, v := range arr {
-		s, err := v.AsStrSlice()
-		if err != nil {
-			return &StringSliceCmd{err: err}
-		}
-		val = append(val, s...)
-	}
-	return &StringSliceCmd{val: val, err: err}
-}
-
 func (cmd *StringSliceCmd) SetVal(val []string) {
 	cmd.val = val
 }
@@ -821,6 +805,113 @@ func (cmd *ScanCmd) Err() error {
 
 func (cmd *ScanCmd) Result() (keys []string, cursor uint64, err error) {
 	return cmd.keys, cmd.cursor, cmd.err
+}
+
+type KeyValue struct {
+	Key   string
+	Value string
+}
+
+type KeyValueSliceCmd struct {
+	err error
+	val []KeyValue
+}
+
+func newKeyValueSliceCmd(res rueidis.RedisResult) *KeyValueSliceCmd {
+	ret := &KeyValueSliceCmd{}
+	val, err := res.AsStrMap()
+	if len(val) > 0 {
+		ret.val = make([]KeyValue, 0, len(val))
+		for k, v := range val {
+			ret.val = append(ret.val, KeyValue{Key: k, Value: v})
+		}
+	}
+	ret.err = err
+	return ret
+}
+
+func (cmd *KeyValueSliceCmd) SetVal(val []KeyValue) {
+	cmd.val = val
+}
+
+func (cmd *KeyValueSliceCmd) SetErr(err error) {
+	cmd.err = err
+}
+
+func (cmd *KeyValueSliceCmd) Val() []KeyValue {
+	return cmd.val
+}
+
+func (cmd *KeyValueSliceCmd) Err() error {
+	return cmd.err
+}
+
+func (cmd *KeyValueSliceCmd) Result() ([]KeyValue, error) {
+	return cmd.val, cmd.err
+}
+
+type KeyValuesCmd struct {
+	err error
+	val rueidis.KeyValues
+}
+
+func newKeyValuesCmd(res rueidis.RedisResult) *KeyValuesCmd {
+	ret := &KeyValuesCmd{}
+	ret.val, ret.err = res.AsLMPop()
+	return ret
+}
+
+func (cmd *KeyValuesCmd) SetVal(key string, val []string) {
+	cmd.val.Key = key
+	cmd.val.Values = val
+}
+
+func (cmd *KeyValuesCmd) SetErr(err error) {
+	cmd.err = err
+}
+
+func (cmd *KeyValuesCmd) Val() (string, []string) {
+	return cmd.val.Key, cmd.val.Values
+}
+
+func (cmd *KeyValuesCmd) Err() error {
+	return cmd.err
+}
+
+func (cmd *KeyValuesCmd) Result() (string, []string, error) {
+	return cmd.val.Key, cmd.val.Values, cmd.err
+}
+
+type ZSliceWithKeyCmd struct {
+	err error
+	val rueidis.KeyZScores
+}
+
+func newZSliceWithKeyCmd(res rueidis.RedisResult) *ZSliceWithKeyCmd {
+	ret := &ZSliceWithKeyCmd{}
+	ret.val, ret.err = res.AsZMPop()
+	return ret
+}
+
+func (cmd *ZSliceWithKeyCmd) SetVal(key string, val []rueidis.ZScore) {
+	cmd.val.Key = key
+	cmd.val.Values = val
+}
+
+func (cmd *ZSliceWithKeyCmd) SetErr(err error) {
+	cmd.err = err
+}
+
+func (cmd *ZSliceWithKeyCmd) Val() (string, []rueidis.ZScore) {
+	return cmd.val.Key, cmd.val.Values
+}
+
+func (cmd *ZSliceWithKeyCmd) Err() error {
+	return cmd.err
+}
+
+func (cmd *ZSliceWithKeyCmd) Result() (string, []rueidis.ZScore, error) {
+	return cmd.val.Key, cmd.val.Values, cmd.err
 }
 
 type StringStringMapCmd struct {

--- a/rueidiscompat/command.go
+++ b/rueidiscompat/command.go
@@ -884,34 +884,41 @@ func (cmd *KeyValuesCmd) Result() (string, []string, error) {
 
 type ZSliceWithKeyCmd struct {
 	err error
-	val rueidis.KeyZScores
+	key string
+	val []Z
 }
 
 func newZSliceWithKeyCmd(res rueidis.RedisResult) *ZSliceWithKeyCmd {
-	ret := &ZSliceWithKeyCmd{}
-	ret.val, ret.err = res.AsZMPop()
-	return ret
+	v, err := res.AsZMPop()
+	if err != nil {
+		return &ZSliceWithKeyCmd{err: err}
+	}
+	val := make([]Z, 0, len(v.Values))
+	for _, s := range v.Values {
+		val = append(val, Z{Member: s.Member, Score: s.Score})
+	}
+	return &ZSliceWithKeyCmd{key: v.Key, val: val}
 }
 
-func (cmd *ZSliceWithKeyCmd) SetVal(key string, val []rueidis.ZScore) {
-	cmd.val.Key = key
-	cmd.val.Values = val
+func (cmd *ZSliceWithKeyCmd) SetVal(key string, val []Z) {
+	cmd.key = key
+	cmd.val = val
 }
 
 func (cmd *ZSliceWithKeyCmd) SetErr(err error) {
 	cmd.err = err
 }
 
-func (cmd *ZSliceWithKeyCmd) Val() (string, []rueidis.ZScore) {
-	return cmd.val.Key, cmd.val.Values
+func (cmd *ZSliceWithKeyCmd) Val() (string, []Z) {
+	return cmd.key, cmd.val
 }
 
 func (cmd *ZSliceWithKeyCmd) Err() error {
 	return cmd.err
 }
 
-func (cmd *ZSliceWithKeyCmd) Result() (string, []rueidis.ZScore, error) {
-	return cmd.val.Key, cmd.val.Values, cmd.err
+func (cmd *ZSliceWithKeyCmd) Result() (string, []Z, error) {
+	return cmd.key, cmd.val, cmd.err
 }
 
 type StringStringMapCmd struct {

--- a/rueidiscompat/command.go
+++ b/rueidiscompat/command.go
@@ -819,11 +819,11 @@ type KeyValueSliceCmd struct {
 
 func newKeyValueSliceCmd(res rueidis.RedisResult) *KeyValueSliceCmd {
 	ret := &KeyValueSliceCmd{}
-	val, err := res.AsStrMap()
-	if len(val) > 0 {
-		ret.val = make([]KeyValue, 0, len(val))
-		for k, v := range val {
-			ret.val = append(ret.val, KeyValue{Key: k, Value: v})
+	arr, err := res.ToArray()
+	for _, a := range arr {
+		kv, _ := a.AsStrSlice()
+		for i := 0; i < len(kv); i += 2 {
+			ret.val = append(ret.val, KeyValue{Key: kv[i], Value: kv[i+1]})
 		}
 	}
 	ret.err = err

--- a/rueidiscompat/command.go
+++ b/rueidiscompat/command.go
@@ -473,9 +473,6 @@ type DurationCmd struct {
 
 func newDurationCmd(res rueidis.RedisResult, precision time.Duration) *DurationCmd {
 	val, err := res.AsInt64()
-	if err != nil {
-		return &DurationCmd{val: 0, err: err}
-	}
 	if val > 0 {
 		return &DurationCmd{val: time.Duration(val) * precision, err: err}
 	}

--- a/rueidiscompat/command_test.go
+++ b/rueidiscompat/command_test.go
@@ -523,6 +523,32 @@ var _ = Describe("Commands", func() {
 			Expect(s).To(Equal("0"))
 			Expect(cmd.Err()).To(BeNil())
 		}
+		{
+			cmd := &KeyValueSliceCmd{}
+			cmd.SetVal([]KeyValue{{Key: "1", Value: "2"}})
+			v := cmd.Val()
+			Expect(v).To(Equal([]KeyValue{{Key: "1", Value: "2"}}))
+			cmd.SetErr(err)
+			Expect(cmd.Err()).To(Equal(err))
+		}
+		{
+			cmd := &KeyValuesCmd{}
+			cmd.SetVal("k", []string{"1"})
+			k, v := cmd.Val()
+			Expect(k).To(Equal("k"))
+			Expect(v).To(Equal([]string{"1"}))
+			cmd.SetErr(err)
+			Expect(cmd.Err()).To(Equal(err))
+		}
+		{
+			cmd := &ZSliceWithKeyCmd{}
+			cmd.SetVal("k", []Z{{Member: "1", Score: 1}})
+			k, v := cmd.Val()
+			Expect(k).To(Equal("k"))
+			Expect(v).To(Equal([]Z{{Member: "1", Score: 1}}))
+			cmd.SetErr(err)
+			Expect(cmd.Err()).To(Equal(err))
+		}
 	})
 })
 


### PR DESCRIPTION
* ExpireTime
* PExpireTime
* SortRO
* HRandField
* HRandFieldWithValues
* BLMPop
* LMPop
* SInterCard
* BZMPop
* ZAddLT
* ZAddGT
* ZInterCard
* ZMPop
* ClientUnblock
* ClientUnblockWithError
* EvalRO
* EvalShaRO
* SPublish
* PubSubShardChannels
* PubSubShardNumSub